### PR TITLE
claude/session-011CUYYWG5bnRpqfAqFweR81

### DIFF
--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -63,6 +63,27 @@ const formatTimeRemaining = (deadline: string): string => {
   }
 };
 
+// Format the end date for completed bets
+const formatEndDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+
+  if (isToday) {
+    // Today: show "Ended 2:30 PM"
+    return `Ended ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}`;
+  }
+
+  const isThisYear = date.getFullYear() === now.getFullYear();
+  if (isThisYear) {
+    // This year: show "Ended Oct 27"
+    return `Ended ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+  }
+
+  // Other year: show "Ended Oct 27, 2024"
+  return `Ended ${date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
+};
+
 export const BetCard: React.FC<BetCardProps> = ({
   bet,
   onPress,
@@ -332,10 +353,16 @@ export const BetCard: React.FC<BetCardProps> = ({
 
       {/* Metadata Row: Time + Participants + Creator */}
       <View style={styles.metadataRow}>
-        {timeRemaining && isActive && (
+        {isActive && timeRemaining && (
           <View style={styles.metadataItem}>
             <Ionicons name="time-outline" size={14} color={colors.textMuted} />
             <Text style={styles.metadataText}>{timeRemaining}</Text>
+          </View>
+        )}
+        {!isActive && bet.updatedAt && (
+          <View style={styles.metadataItem}>
+            <Ionicons name="calendar-outline" size={14} color={colors.textMuted} />
+            <Text style={styles.metadataText}>{formatEndDate(bet.updatedAt)}</Text>
           </View>
         )}
         <View style={styles.metadataItem}>


### PR DESCRIPTION
1. Auto-checkout when event ends:
   - Already implemented in live-score-updater Lambda
   - Automatically checks out users when event status changes to FINISHED

2. Show end date instead of countdown on completed bets:
   - Added formatEndDate() utility to format bet end dates
   - Display "Ended [time/date]" for non-ACTIVE bets on bet cards
   - Shows time if today, date if this year, full date with year otherwise

3. Default values with clear-on-focus for bet creation sides:
   - Added sideAEdited/sideBEdited state tracking
   - Sides fields now have default values (not just placeholders)
   - Values clear on first focus when they're defaults
   - Team names from check-in don't clear (marked as edited)
   - Locked sides (Yes/No, Over/Under) don't clear

4. Fix check-in/out state synchronization:
   - Added useFocusEffect to refresh check-in state on screen focus
   - Side names reset to defaults when checking out
   - Side names update to team names when checking in
   - State properly syncs across all screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)