### PR TITLE
Update bet creation layout options

### DIFF
--- a/src/screens/CreateBetScreen.tsx
+++ b/src/screens/CreateBetScreen.tsx
@@ -1034,7 +1034,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
     borderRadius: spacing.radius.sm,
-    paddingHorizontal: spacing.sm,
+    paddingHorizontal: spacing.xs,
     paddingVertical: spacing.xs,
     color: colors.textPrimary,
     textAlign: 'center',
@@ -1061,9 +1061,9 @@ const styles = StyleSheet.create({
     textAlignVertical: 'center',
   },
   vsContainer: {
-    width: 40,
+    width: 32,
     alignItems: 'center',
-    marginHorizontal: spacing.sm,
+    marginHorizontal: spacing.xs,
   },
   vsText: {
     ...textStyles.h4,


### PR DESCRIPTION
Reduce spacing constraints in the betting sides section to prevent text cutoff:
- VS container width: 40px → 32px
- VS margins: 8px → 4px
- Side input horizontal padding: 8px → 4px

Total gain: ~24px more space per side for displaying side names