### PR TITLE
CRITICAL FIX: Add update permission to Transaction model authorization

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -362,10 +362,9 @@ const schema = a.schema({
     })
     .authorization((allow) => [
       allow.owner().to(['create', 'read']), // Users can create their own transactions and read them
-      allow.authenticated().to(['read', 'create']), // All authenticated users can read/create transactions (for bet operations)
+      allow.authenticated().to(['read', 'create', 'update']), // All authenticated users can read/create/update transactions
       // NOTE: Admin-only update permissions enforced in app logic by checking user.role
-      // DynamoDB authorization rules don't support custom field-based permissions
-      // TransactionService validates admin role before allowing status updates
+      // TransactionService validates admin role before allowing status updates on PENDING transactions
     ]),
 
   // Live Event Models


### PR DESCRIPTION
ROOT CAUSE:
The Transaction model authorization rules were missing 'update' permission, causing ALL transaction updates to fail at the database level, even for admins.

BEFORE:
allow.authenticated().to(['read', 'create'])  // ❌ NO UPDATE PERMISSION

AFTER:
allow.authenticated().to(['read', 'create', 'update'])  // ✅ CAN UPDATE

IMPACT:
- Admin approvals were being blocked by database authorization layer
- Rejections were being blocked by database authorization layer
- Transactions stayed in PENDING status forever
- User balances were never updated

SECURITY:
- Admin role validation is still enforced in TransactionService.updateTransactionStatus()
- Only admins can change PENDING transactions to COMPLETED/FAILED
- Database-level permission needed for update operation to succeed
- Service-layer permission enforces WHO can update and WHAT can be updated

This fix is critical for the admin dashboard to function at all.