### PR TITLE
Fix duplicate events in live events list

### DIFF
--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -164,8 +164,22 @@ export const LiveEventsScreen: React.FC = () => {
       try {
         console.log('🎯 Fetching recommended events for user:', user.userId);
         const events = await getRecommendedUpcomingEvents(user.userId, 5);
-        console.log(`✅ Loaded ${events.length} recommended events`);
-        setRecommendedEvents(events);
+
+        // Deduplicate events by ID as a safety measure
+        const uniqueEventsMap = new Map();
+        events.forEach(event => {
+          if (event.id && !uniqueEventsMap.has(event.id)) {
+            uniqueEventsMap.set(event.id, event);
+          }
+        });
+        const uniqueEvents = Array.from(uniqueEventsMap.values());
+
+        if (uniqueEvents.length !== events.length) {
+          console.warn(`⚠️ Deduplicated ${events.length - uniqueEvents.length} duplicate recommended events`);
+        }
+
+        console.log(`✅ Loaded ${uniqueEvents.length} unique recommended events`);
+        setRecommendedEvents(uniqueEvents);
       } catch (error) {
         console.error('❌ Error fetching recommended events:', error);
       }


### PR DESCRIPTION
This commit addresses the issue where live/upcoming events were appearing twice in the UI, but not consistently for every event.

Root Cause:
- EventDiscoveryModal had a race condition where the automatic tab switch from "live" to "upcoming" (when no live events exist) would trigger the useEffect again, causing two simultaneous API calls to fetch upcoming events
- This created timing-dependent duplicates in the UI

Fixes Applied:

1. EventDiscoveryModal.tsx:
   - Added isLoadingRef flag to prevent concurrent loads
   - When automatically switching tabs, the function now exits early and lets the useEffect handle the reload with the new tab
   - Added Map-based deduplication of events by ID as a safety measure
   - Added console warning when duplicates are detected

2. LiveEventsScreen.tsx:
   - Added Map-based deduplication for recommended events
   - Added console warning when duplicates are detected

Technical Details:
- The loading flag prevents the race condition where setActiveTab triggers a second load while the first is still processing
- The deduplication logic using Map ensures no duplicate IDs appear in the final event list, even if the API returns duplicates
- Console warnings help identify if duplicates are coming from the backend

Testing:
- Open EventDiscoveryModal with no live events (should auto-switch to upcoming)
- Check console for "Load already in progress" message (confirms fix working)
- Check console for deduplication warnings (if any duplicates detected)
- Verify no duplicate events appear in the UI