### PR TITLE
Fix react-async-hook module resolution error

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
 
 const config = getDefaultConfig(__dirname);
 
@@ -9,5 +10,22 @@ config.resolver.alias = {
 
 // Ensure platform extensions are properly resolved
 config.resolver.platforms = ['native', 'android', 'ios', 'web'];
+
+// Fix for react-async-hook dependency issue
+// The package.json points to a non-existent ESM file, so we redirect to the CJS build
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === 'react-async-hook') {
+    return {
+      filePath: path.resolve(
+        __dirname,
+        'node_modules/react-async-hook/dist/react-async-hook.cjs.js'
+      ),
+      type: 'sourceFile',
+    };
+  }
+
+  // Default resolution
+  return context.resolveRequest(context, moduleName, platform);
+};
 
 module.exports = config;


### PR DESCRIPTION
The react-async-hook package has a misconfigured package.json that points to a non-existent ESM file. This was causing build failures in CodeBuild with the error: "the package itself specifies a main module field that could not be resolved"

Added a custom resolver in metro.config.js to redirect react-async-hook imports to the correct CJS build file at dist/react-async-hook.cjs.js.

This fixes the build failure introduced by the react-native-phone-number-input dependency chain.