### PR TITLE
Simplify react-async-hook module resolution fix

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,4 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const path = require('path');
 
 const config = getDefaultConfig(__dirname);
 
@@ -12,20 +11,9 @@ config.resolver.alias = {
 config.resolver.platforms = ['native', 'android', 'ios', 'web'];
 
 // Fix for react-async-hook dependency issue
-// The package.json points to a non-existent ESM file, so we redirect to the CJS build
-config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (moduleName === 'react-async-hook') {
-    return {
-      filePath: path.resolve(
-        __dirname,
-        'node_modules/react-async-hook/dist/react-async-hook.cjs.js'
-      ),
-      type: 'sourceFile',
-    };
-  }
-
-  // Default resolution
-  return context.resolveRequest(context, moduleName, platform);
-};
+// The package.json incorrectly points to "module": "react-async-hook.esm.js"
+// but the file is actually at "dist/react-async-hook.esm.js"
+// We configure Metro to prefer the "main" field over "module" field
+config.resolver.resolverMainFields = ['react-native', 'browser', 'main'];
 
 module.exports = config;


### PR DESCRIPTION
Changed approach from custom file resolution to configuring Metro's resolverMainFields. This tells Metro to prefer the "main" field over the broken "module" field in react-async-hook's package.json.

This is cleaner and avoids file existence checks that were causing SHA-1 errors in CodeBuild.