### PR TITLE
Remove react-native-phone-number-input and simplify to US-only phone …

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,13 +1,10 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const path = require('path');
 
 const config = getDefaultConfig(__dirname);
 
 // Crypto polyfill for React Native compatibility
-// Fix for react-async-hook dependency issue - redirect to working file
 config.resolver.alias = {
   'crypto': 'react-native-get-random-values',
-  'react-async-hook': path.resolve(__dirname, 'node_modules/react-async-hook/dist/index.js'),
 };
 
 // Ensure platform extensions are properly resolved

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-get-random-values": "~1.11.0",
-    "react-native-phone-number-input": "^2.1.0",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",


### PR DESCRIPTION
…input

PROBLEM:
- react-native-phone-number-input brought in react-async-hook with broken package.json
- This caused CodeBuild failures since PR #25
- App is currently US-only, so complex country picker was unnecessary

SOLUTION:
- Removed react-native-phone-number-input dependency
- Simplified PhoneInput.tsx to US-only TextInput with libphonenumber-js formatting
- Displays: 🇺🇸 +1 (XXX) XXX-XXXX
- Stores: E.164 format (+1XXXXXXXXXX) for future international expansion
- Removed metro.config.js workaround (no longer needed)

BENEFITS:
- No broken dependencies
- Cleaner, simpler code
- Still validates and stores phone numbers properly
- Easy to add country selector later if needed