### PR TITLE
Fix duplicate database entries in ESPN service

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -415,6 +415,7 @@ const schema = a.schema({
     })
     .secondaryIndexes((index) => [
       index('status').sortKeys(['scheduledTime']).queryField('listEventsByStatusAndTime'),
+      index('externalId').queryField('listEventsByExternalId'),
     ])
     .authorization((allow) => [
       allow.authenticated().to(['read', 'create', 'update']) // All authenticated users can read, Lambda functions can create/update


### PR DESCRIPTION
…ction

Changes:
1. Add secondary index on LiveEvent.externalId for efficient duplicate lookups
2. Update event-fetcher Lambda to use GSI instead of filter-based queries
3. Add automatic cleanup of existing duplicates when detected
4. Add comprehensive error handling to prevent silent failures

This fixes the issue where the Lambda was creating multiple database entries for the same ESPN event due to race conditions and unreliable filter queries.