### PR TITLE
Replace badge indicators with shortened team names

### DIFF
--- a/src/components/ui/LiveGameBanner.tsx
+++ b/src/components/ui/LiveGameBanner.tsx
@@ -15,6 +15,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { colors, typography, spacing, textStyles } from '../../styles';
 import type { LiveEvent } from '../../types/events';
+import { formatTeamName } from '../../utils/formatting';
 
 export interface LiveGameData {
   homeTeam: string;
@@ -83,6 +84,9 @@ export const LiveGameBanner: React.FC<LiveGameBannerProps> = ({
     }
   };
 
+  const homeShort = formatTeamName(checkedInEvent.homeTeam, checkedInEvent.homeTeamCode);
+  const awayShort = formatTeamName(checkedInEvent.awayTeam, checkedInEvent.awayTeamCode);
+
   return (
     <TouchableOpacity
       style={styles.checkedInContainer}
@@ -94,11 +98,7 @@ export const LiveGameBanner: React.FC<LiveGameBannerProps> = ({
           <Ionicons name="location" size={20} color={colors.primary} />
           <View style={styles.eventInfo}>
             <Text style={styles.eventName} numberOfLines={1}>
-              {checkedInEvent.homeTeam}{' '}
-              <Text style={styles.teamBadge}>H</Text>
-              {' vs '}
-              {checkedInEvent.awayTeam}{' '}
-              <Text style={styles.teamBadge}>A</Text>
+              {awayShort} @ {homeShort}
             </Text>
           </View>
         </View>
@@ -182,18 +182,6 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     fontSize: typography.fontSize.sm,
     fontWeight: typography.fontWeight.medium,
-  },
-  teamBadge: {
-    fontSize: typography.fontSize.xs,
-    fontWeight: typography.fontWeight.semibold,
-    color: colors.textSecondary,
-    backgroundColor: colors.surface,
-    paddingHorizontal: spacing.xs / 2,
-    paddingVertical: 1,
-    borderRadius: spacing.radius.xs,
-    borderWidth: 1,
-    borderColor: colors.border,
-    overflow: 'hidden',
   },
   checkedInRight: {
     flexDirection: 'row',

--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -28,6 +28,7 @@ import { bulkLoadJoinableBetsWithParticipants, bulkLoadFriendsBetsWithParticipan
 import { QRScannerModal } from '../components/ui/QRScannerModal';
 import { getUpcomingEventsFromCache } from '../services/eventCacheService';
 import type { LiveEventData } from '../services/eventService';
+import { formatTeamName } from '../utils/formatting';
 
 // Initialize GraphQL client
 const client = generateClient<Schema>();
@@ -515,15 +516,14 @@ export const LiveEventsScreen: React.FC = () => {
                 timeText = 'Starting soon';
               }
 
+              const awayShort = formatTeamName(event.awayTeam, event.awayTeamCode);
+              const homeShort = formatTeamName(event.homeTeam, event.homeTeamCode);
+
               return (
                 <View key={event.id} style={styles.upcomingEvent}>
                   <View style={styles.upcomingHeader}>
                     <Text style={styles.upcomingTitle}>
-                      {event.awayTeam}{' '}
-                      <Text style={styles.teamBadge}>A</Text>
-                      {' @ '}
-                      {event.homeTeam}{' '}
-                      <Text style={styles.teamBadge}>H</Text>
+                      {awayShort} @ {homeShort}
                     </Text>
                     <Text style={styles.upcomingStatus}>{event.sport}</Text>
                   </View>
@@ -777,18 +777,6 @@ const styles = StyleSheet.create({
     ...textStyles.h4,
     color: colors.textPrimary,
     flex: 1,
-  },
-  teamBadge: {
-    fontSize: typography.fontSize.xs,
-    fontWeight: typography.fontWeight.semibold,
-    color: colors.textSecondary,
-    backgroundColor: colors.surface,
-    paddingHorizontal: spacing.xs / 2,
-    paddingVertical: 1,
-    borderRadius: spacing.radius.xs,
-    borderWidth: 1,
-    borderColor: colors.border,
-    overflow: 'hidden',
   },
   upcomingStatus: {
     ...textStyles.caption,

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -231,3 +231,15 @@ export const formatErrorMessage = (error: any): string => {
   if (error?.code) return `Error: ${error.code}`;
   return 'An unexpected error occurred';
 };
+
+// Team name formatting - extracts short name for display
+export const formatTeamName = (fullTeamName: string, teamCode?: string): string => {
+  // Use team code if available (e.g., "LAL", "GSW")
+  if (teamCode && teamCode.trim()) {
+    return teamCode.trim();
+  }
+
+  // Extract last word from full team name (e.g., "Pittsburgh Steelers" -> "Steelers")
+  const words = fullTeamName.trim().split(/\s+/);
+  return words[words.length - 1];
+};


### PR DESCRIPTION
- Remove (H)/(A) badge indicators from event displays
- Add formatTeamName utility to extract short team names
- Use team codes when available, otherwise extract last word
- Format: "Steelers @ Browns" instead of "Pittsburgh Steelers @ Cleveland Browns"
- Saves significant space in banner and event list displays