### PR TITLE
Store short team names from ESPN API in database

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -386,6 +386,8 @@ const schema = a.schema({
       // Event details
       homeTeam: a.string().required(),
       awayTeam: a.string().required(),
+      homeTeamShortName: a.string(), // e.g., "Steelers", "Browns" - from ESPN team.name
+      awayTeamShortName: a.string(),
       homeTeamCode: a.string(), // e.g., "LAL", "GSW"
       awayTeamCode: a.string(),
       // Venue

--- a/amplify/functions/event-fetcher/handler.ts
+++ b/amplify/functions/event-fetcher/handler.ts
@@ -241,6 +241,8 @@ async function upsertEvent(event: ESPNEvent, league: string): Promise<void> {
       league: league,
       homeTeam: homeCompetitor.team.displayName || homeCompetitor.team.name,
       awayTeam: awayCompetitor.team.displayName || awayCompetitor.team.name,
+      homeTeamShortName: homeCompetitor.team.name, // Short name (e.g., "Steelers")
+      awayTeamShortName: awayCompetitor.team.name, // Short name (e.g., "Browns")
       homeTeamCode: homeCompetitor.team.abbreviation,
       awayTeamCode: awayCompetitor.team.abbreviation,
       venue: competition.venue?.fullName || undefined,

--- a/src/components/ui/LiveGameBanner.tsx
+++ b/src/components/ui/LiveGameBanner.tsx
@@ -84,8 +84,8 @@ export const LiveGameBanner: React.FC<LiveGameBannerProps> = ({
     }
   };
 
-  const homeShort = formatTeamName(checkedInEvent.homeTeam, checkedInEvent.homeTeamCode);
-  const awayShort = formatTeamName(checkedInEvent.awayTeam, checkedInEvent.awayTeamCode);
+  const homeShort = formatTeamName(checkedInEvent.homeTeam, checkedInEvent.homeTeamShortName, checkedInEvent.homeTeamCode);
+  const awayShort = formatTeamName(checkedInEvent.awayTeam, checkedInEvent.awayTeamShortName, checkedInEvent.awayTeamCode);
 
   return (
     <TouchableOpacity

--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -516,8 +516,8 @@ export const LiveEventsScreen: React.FC = () => {
                 timeText = 'Starting soon';
               }
 
-              const awayShort = formatTeamName(event.awayTeam, event.awayTeamCode);
-              const homeShort = formatTeamName(event.homeTeam, event.homeTeamCode);
+              const awayShort = formatTeamName(event.awayTeam, event.awayTeamShortName, event.awayTeamCode);
+              const homeShort = formatTeamName(event.homeTeam, event.homeTeamShortName, event.homeTeamCode);
 
               return (
                 <View key={event.id} style={styles.upcomingEvent}>

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -20,6 +20,8 @@ export interface LiveEventData {
   league: string;
   homeTeam: string;
   awayTeam: string;
+  homeTeamShortName?: string;
+  awayTeamShortName?: string;
   homeTeamCode?: string;
   awayTeamCode?: string;
   venue?: string;
@@ -116,6 +118,8 @@ export async function getUserCheckedInEvent(userId: string): Promise<{
         league: event.league || '',
         homeTeam: event.homeTeam,
         awayTeam: event.awayTeam,
+        homeTeamShortName: event.homeTeamShortName ?? undefined,
+        awayTeamShortName: event.awayTeamShortName ?? undefined,
         homeTeamCode: event.homeTeamCode ?? undefined,
         awayTeamCode: event.awayTeamCode ?? undefined,
         venue: event.venue ?? undefined,
@@ -297,6 +301,8 @@ export async function getUpcomingEvents(
       league: event.league || '',
       homeTeam: event.homeTeam,
       awayTeam: event.awayTeam,
+      homeTeamShortName: event.homeTeamShortName ?? undefined,
+      awayTeamShortName: event.awayTeamShortName ?? undefined,
       homeTeamCode: event.homeTeamCode ?? undefined,
       awayTeamCode: event.awayTeamCode ?? undefined,
       venue: event.venue ?? undefined,
@@ -363,6 +369,8 @@ export async function getTrendingEvents(limit: number = 20): Promise<LiveEventDa
       league: event.league || '',
       homeTeam: event.homeTeam,
       awayTeam: event.awayTeam,
+      homeTeamShortName: event.homeTeamShortName ?? undefined,
+      awayTeamShortName: event.awayTeamShortName ?? undefined,
       homeTeamCode: event.homeTeamCode ?? undefined,
       awayTeamCode: event.awayTeamCode ?? undefined,
       venue: event.venue ?? undefined,
@@ -445,6 +453,8 @@ export async function getLiveEvents(
       league: event.league || '',
       homeTeam: event.homeTeam,
       awayTeam: event.awayTeam,
+      homeTeamShortName: event.homeTeamShortName ?? undefined,
+      awayTeamShortName: event.awayTeamShortName ?? undefined,
       homeTeamCode: event.homeTeamCode ?? undefined,
       awayTeamCode: event.awayTeamCode ?? undefined,
       venue: event.venue ?? undefined,
@@ -493,6 +503,8 @@ export async function getEventById(eventId: string): Promise<LiveEventData | nul
       league: event.league || '',
       homeTeam: event.homeTeam,
       awayTeam: event.awayTeam,
+      homeTeamShortName: event.homeTeamShortName ?? undefined,
+      awayTeamShortName: event.awayTeamShortName ?? undefined,
       homeTeamCode: event.homeTeamCode ?? undefined,
       awayTeamCode: event.awayTeamCode ?? undefined,
       venue: event.venue ?? undefined,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -15,6 +15,8 @@ export interface LiveEvent {
   league: string;
   homeTeam: string;
   awayTeam: string;
+  homeTeamShortName?: string; // e.g., "Steelers", "Browns"
+  awayTeamShortName?: string;
   homeTeamCode?: string; // e.g., "LAL", "GSW"
   awayTeamCode?: string;
   venue?: string;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -233,13 +233,18 @@ export const formatErrorMessage = (error: any): string => {
 };
 
 // Team name formatting - extracts short name for display
-export const formatTeamName = (fullTeamName: string, teamCode?: string): string => {
-  // Use team code if available (e.g., "LAL", "GSW")
+export const formatTeamName = (fullTeamName: string, shortName?: string, teamCode?: string): string => {
+  // Prefer short name from ESPN if available (e.g., "Steelers", "Browns")
+  if (shortName && shortName.trim()) {
+    return shortName.trim();
+  }
+
+  // Fallback to team code if available (e.g., "LAL", "GSW")
   if (teamCode && teamCode.trim()) {
     return teamCode.trim();
   }
 
-  // Extract last word from full team name (e.g., "Pittsburgh Steelers" -> "Steelers")
+  // Last resort: extract last word from full team name (e.g., "Pittsburgh Steelers" -> "Steelers")
   const words = fullTeamName.trim().split(/\s+/);
   return words[words.length - 1];
 };


### PR DESCRIPTION
- Add homeTeamShortName and awayTeamShortName fields to LiveEvent schema
- Update event-fetcher to store ESPN team.name (e.g., "Steelers") directly
- Update formatTeamName utility to prioritize short names from database
- Modify all event display components to use short names
- Short names now come from ESPN API instead of client-side extraction
- Fallback logic: shortName -> teamCode -> last word extraction