### PR TITLE
Add lost bets to history tracking

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -339,6 +339,7 @@ const schema = a.schema({
         'WITHDRAWAL',        // User withdraws funds
         'BET_PLACED',        // Balance deducted when joining bet
         'BET_WON',          // Winnings paid out
+        'BET_LOST',         // Lost bet (zero amount, for tracking only)
         'BET_CANCELLED',    // Refund when bet cancelled
         'BET_REFUND',       // Manual refund by admin
         'ADMIN_ADJUSTMENT'  // Admin balance correction

--- a/src/screens/BettingHistoryScreen.tsx
+++ b/src/screens/BettingHistoryScreen.tsx
@@ -26,7 +26,7 @@ interface BettingHistoryScreenProps {
   onClose: () => void;
 }
 
-type FilterType = 'ALL' | 'DEPOSITS' | 'WITHDRAWALS' | 'BETS' | 'WINNINGS' | 'REFUNDS';
+type FilterType = 'ALL' | 'DEPOSITS' | 'WITHDRAWALS' | 'BETS' | 'WINNINGS' | 'LOSSES' | 'REFUNDS';
 
 export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onClose }) => {
   const { user } = useAuth();
@@ -82,6 +82,7 @@ export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onCl
         WITHDRAWALS: ['WITHDRAWAL'],
         BETS: ['BET_PLACED'],
         WINNINGS: ['BET_WON'],
+        LOSSES: ['BET_LOST'],
         REFUNDS: ['BET_CANCELLED', 'BET_REFUND'],
       };
 
@@ -138,6 +139,7 @@ export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onCl
           {renderFilterButton('WITHDRAWALS', 'Withdrawals', 'arrow-up-circle-outline')}
           {renderFilterButton('BETS', 'Bets', 'game-controller-outline')}
           {renderFilterButton('WINNINGS', 'Wins', 'trophy-outline')}
+          {renderFilterButton('LOSSES', 'Losses', 'close-circle-outline')}
           {renderFilterButton('REFUNDS', 'Refunds', 'refresh-outline')}
         </View>
       </ScrollView>
@@ -182,6 +184,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
       case 'WITHDRAWAL': return 'arrow-up-circle';
       case 'BET_PLACED': return 'game-controller';
       case 'BET_WON': return 'trophy';
+      case 'BET_LOST': return 'close-circle';
       case 'BET_CANCELLED':
       case 'BET_REFUND': return 'refresh-circle';
       case 'ADMIN_ADJUSTMENT': return 'settings';
@@ -202,6 +205,8 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
       case 'WITHDRAWAL':
       case 'BET_PLACED':
         return colors.error;
+      case 'BET_LOST':
+        return colors.textMuted; // Neutral color for lost bets (no balance change)
       case 'ADMIN_ADJUSTMENT':
         return colors.info;
       default:
@@ -215,6 +220,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
       case 'WITHDRAWAL': return 'Withdrawal';
       case 'BET_PLACED': return 'Bet Placed';
       case 'BET_WON': return 'Bet Won';
+      case 'BET_LOST': return 'Bet Lost';
       case 'BET_CANCELLED': return 'Bet Cancelled';
       case 'BET_REFUND': return 'Refund';
       case 'ADMIN_ADJUSTMENT': return 'Adjustment';
@@ -238,6 +244,8 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
         return 'Joined a bet';
       case 'BET_WON':
         return 'Winnings payout';
+      case 'BET_LOST':
+        return 'Lost bet - tracking record';
       case 'BET_CANCELLED':
         return 'Bet cancelled - refund';
       case 'BET_REFUND':
@@ -282,6 +290,11 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
   };
 
   const formatAmount = () => {
+    // BET_LOST is a zero-amount tracking transaction
+    if (transaction.type === 'BET_LOST') {
+      return formatCurrency(0);
+    }
+
     const isCredit = transaction.type === 'DEPOSIT' ||
                      transaction.type === 'BET_WON' ||
                      transaction.type === 'BET_CANCELLED' ||
@@ -306,6 +319,9 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
                    transaction.type === 'BET_WON' ||
                    transaction.type === 'BET_CANCELLED' ||
                    transaction.type === 'BET_REFUND';
+
+  // BET_LOST is neutral (no balance change)
+  const isNeutral = transaction.type === 'BET_LOST';
 
   return (
     <View style={[styles.transactionCard, { borderLeftColor: getTransactionColor() }]}>
@@ -333,7 +349,7 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
         <View style={styles.transactionAmountContainer}>
           <Text style={[
             styles.transactionAmount,
-            isCredit ? styles.transactionAmountCredit : styles.transactionAmountDebit,
+            isNeutral ? styles.transactionAmountNeutral : (isCredit ? styles.transactionAmountCredit : styles.transactionAmountDebit),
           ]}>
             {formatAmount()}
           </Text>
@@ -529,6 +545,9 @@ const styles = StyleSheet.create({
   },
   transactionAmountDebit: {
     color: colors.error,
+  },
+  transactionAmountNeutral: {
+    color: colors.textMuted,
   },
   transactionBalance: {
     ...textStyles.caption,

--- a/src/screens/ResolveScreen.tsx
+++ b/src/screens/ResolveScreen.tsx
@@ -309,11 +309,18 @@ export const ResolveScreen: React.FC = () => {
               status: isWinner ? 'ACCEPTED' : 'DECLINED'
             });
 
-            // Record transaction for winners
+            // Record transaction for winners and losers
             if (isWinner && payout > 0) {
               await TransactionService.recordBetWinnings(
                 participant.userId,
                 payout,
+                bet.id,
+                participant.id
+              );
+            } else if (!isWinner) {
+              // Record lost bet transaction (zero amount, for tracking/dispute)
+              await TransactionService.recordBetLoss(
+                participant.userId,
                 bet.id,
                 participant.id
               );

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -15,6 +15,7 @@ export type TransactionType =
   | 'WITHDRAWAL'
   | 'BET_PLACED'
   | 'BET_WON'
+  | 'BET_LOST'
   | 'BET_CANCELLED'
   | 'BET_REFUND'
   | 'ADMIN_ADJUSTMENT';
@@ -302,6 +303,25 @@ export class TransactionService {
     }
 
     return transaction;
+  }
+
+  /**
+   * Record a lost bet (zero amount, for tracking and dispute purposes)
+   */
+  static async recordBetLoss(
+    userId: string,
+    betId: string,
+    participantId?: string
+  ): Promise<Transaction | null> {
+    return await this.createTransaction({
+      userId,
+      type: 'BET_LOST',
+      amount: 0, // Zero amount - user already paid when joining bet
+      status: 'COMPLETED',
+      relatedBetId: betId,
+      relatedParticipantId: participantId,
+      notes: 'Bet lost',
+    });
   }
 
   /**


### PR DESCRIPTION
Added BET_LOST transaction type to track lost bets for transparency and dispute resolution.

Changes:
- Schema: Added BET_LOST to Transaction type enum
- Service: Created TransactionService.recordBetLoss() method for zero-amount tracking
- Resolution: Updated ResolveScreen to create BET_LOST transactions for losing participants
- UI: Added "Losses" filter and proper display styling in BettingHistoryScreen
  - Neutral gray color for lost bets
  - Zero amount display ($0.00)
  - "Lost bet - tracking record" description

Lost bets now appear in transaction history with:
- $0.00 amount (no balance change since user paid when joining)
- balanceBefore = balanceAfter
- Link to bet and participant for dispute tracking
- Close-circle icon with neutral styling