### PR TITLE
Fix PENDING_RESOLUTION UX consistency issues

### DIFF
--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -292,7 +292,8 @@ export const BetCard: React.FC<BetCardProps> = ({
     if ((status === 'RESOLVED' || status === 'PENDING_RESOLUTION') && userParticipation.hasJoined && bet.winningSide) {
       const isWinner = userParticipation.side === bet.winningSide;
       if (status === 'PENDING_RESOLUTION') {
-        return isWinner ? 'WON (PENDING)' : 'LOST';
+        // Both winners and losers show (PENDING) during dispute window
+        return isWinner ? 'WON (PENDING)' : 'LOST (PENDING)';
       }
       return isWinner ? 'WON' : 'LOST';
     }
@@ -524,8 +525,8 @@ export const BetCard: React.FC<BetCardProps> = ({
                 </Text>
               )}
 
-              {/* File Dispute Button - Only for participants, not creator */}
-              {userParticipation.hasJoined && !isCreator && (
+              {/* File Dispute Button - Available for all participants including creator */}
+              {userParticipation.hasJoined && (
                 <TouchableOpacity
                   style={styles.disputeButton}
                   onPress={() => setShowDisputeModal(true)}

--- a/src/screens/ResolveScreen.tsx
+++ b/src/screens/ResolveScreen.tsx
@@ -499,52 +499,8 @@ export const ResolveScreen: React.FC = () => {
                 onPress={handleBetPress}
               />
 
-              {/* PENDING_RESOLUTION: Two states based on winningSide */}
-              {bet.status === 'PENDING_RESOLUTION' && (
-                <>
-                  {/* State 1: Awaiting creator's decision (no winningSide yet) */}
-                  {!bet.winningSide && (
-                    <View style={styles.awaitingResolutionInfo}>
-                      <View style={styles.awaitingResolutionHeader}>
-                        <Text style={styles.awaitingResolutionTitle}>⏳ Awaiting Resolution</Text>
-                      </View>
-                      <Text style={styles.awaitingResolutionMessage}>
-                        Please select the winning side below to complete the resolution. Participants will be notified once you declare the winner.
-                      </Text>
-                    </View>
-                  )}
-
-                  {/* State 2: Winner declared, dispute window active (winningSide is set) */}
-                  {bet.winningSide && bet.disputeWindowEndsAt && (
-                    <View style={styles.pendingResolutionInfo}>
-                      <View style={styles.pendingResolutionHeader}>
-                        <Text style={styles.pendingResolutionTitle}>✓ Bet Resolved</Text>
-                        <Text style={styles.pendingResolutionWinner}>
-                          Winner: {bet.winningSide === 'A' ? bet.odds.sideAName : bet.odds.sideBName}
-                        </Text>
-                      </View>
-                      <Text style={styles.pendingResolutionMessage}>
-                        Payouts will be distributed automatically in {' '}
-                        {(() => {
-                          const now = new Date();
-                          const endsAt = new Date(bet.disputeWindowEndsAt);
-                          const hoursRemaining = Math.max(0, Math.ceil((endsAt.getTime() - now.getTime()) / (1000 * 60 * 60)));
-                          return `${hoursRemaining} hours`;
-                        })()}
-                        {' '}if no disputes are filed.
-                      </Text>
-                      {bet.creatorId !== user?.userId && (
-                        <Text style={styles.pendingResolutionSubtext}>
-                          You can file a dispute if you believe this resolution is incorrect.
-                        </Text>
-                      )}
-                    </View>
-                  )}
-                </>
-              )}
-
-              {/* Resolution Actions - Only show if user is creator AND bet is ACTIVE (not already resolved) */}
-              {bet.creatorId === user?.userId && bet.status === 'ACTIVE' && (
+              {/* Resolution Actions - Only show if user is creator AND bet needs resolution */}
+              {bet.creatorId === user?.userId && (bet.status === 'ACTIVE' || (bet.status === 'PENDING_RESOLUTION' && !bet.winningSide)) && (
                 <View style={styles.resolutionActions}>
                   {/* Payout Preview */}
                   <View style={styles.payoutPreview}>
@@ -836,75 +792,5 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: typography.fontSize.xs,
     textAlign: 'center',
-  },
-
-  // Awaiting Resolution Info (PENDING_RESOLUTION without winningSide)
-  awaitingResolutionInfo: {
-    backgroundColor: colors.textMuted + '10',
-    marginHorizontal: spacing.md,
-    borderRadius: spacing.radius.sm,
-    padding: spacing.md,
-    borderWidth: 1,
-    borderColor: colors.textMuted + '30',
-    borderTopWidth: 0,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-  },
-  awaitingResolutionHeader: {
-    marginBottom: spacing.sm,
-    paddingBottom: spacing.sm,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.textMuted + '30',
-  },
-  awaitingResolutionTitle: {
-    ...textStyles.h4,
-    color: colors.textSecondary,
-    fontWeight: typography.fontWeight.bold,
-  },
-  awaitingResolutionMessage: {
-    ...textStyles.body,
-    color: colors.textSecondary,
-    lineHeight: 20,
-  },
-
-  // Pending Resolution Info (PENDING_RESOLUTION with winningSide)
-  pendingResolutionInfo: {
-    backgroundColor: colors.warning + '15',
-    marginHorizontal: spacing.md,
-    borderRadius: spacing.radius.sm,
-    padding: spacing.md,
-    borderWidth: 1,
-    borderColor: colors.warning + '40',
-    borderTopWidth: 0,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-  },
-  pendingResolutionHeader: {
-    marginBottom: spacing.sm,
-    paddingBottom: spacing.sm,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.warning + '30',
-  },
-  pendingResolutionTitle: {
-    ...textStyles.h4,
-    color: colors.success,
-    fontWeight: typography.fontWeight.bold,
-    marginBottom: spacing.xs / 2,
-  },
-  pendingResolutionWinner: {
-    ...textStyles.button,
-    color: colors.textPrimary,
-    fontWeight: typography.fontWeight.semibold,
-  },
-  pendingResolutionMessage: {
-    ...textStyles.body,
-    color: colors.textSecondary,
-    lineHeight: 20,
-    marginBottom: spacing.xs,
-  },
-  pendingResolutionSubtext: {
-    ...textStyles.caption,
-    color: colors.textMuted,
-    fontStyle: 'italic',
   },
 });


### PR DESCRIPTION
**Issues Fixed:**

1. **Losers now show "(PENDING)" status**
   - Changed from "LOST" to "LOST (PENDING)"
   - Makes it clear outcome isn't final until dispute window passes
   - Consistent with winners showing "WON (PENDING)"

2. **Creators see same UI as participants on My Bets**
   - Removed `!isCreator` check on File Dispute button
   - Creators can now see dispute state and file disputes if they participated
   - Consistent experience regardless of role

3. **Removed duplicate banners from ResolveScreen**
   - BetCard already shows all state (awaiting resolution, dispute window, etc.)
   - Removed redundant info banners that repeated the same information
   - Cleaner, less cluttered UI

**Result:**
- Consistent PENDING_RESOLUTION experience across all user roles
- Clear indication that outcome is not final during dispute window
- Single source of truth for bet state (BetCard component)