### PR TITLE
Fix active bets badge to exclude pending

### DIFF
--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -63,11 +63,12 @@ export const TabBar: React.FC<BottomTabBarProps> = ({
             })
           );
 
-          // Count user's bets (creator or participant)
+          // Count user's bets (creator or participant) - exclude PENDING_RESOLUTION
           const myBetsCount = betsWithParticipants.filter(({ bet, participants }) => {
             const isCreator = bet.creatorId === user.userId;
             const isParticipant = participants.some(p => p.userId === user.userId);
-            return isCreator || isParticipant;
+            const isActiveBet = bet.status === 'ACTIVE' || bet.status === 'LIVE';
+            return (isCreator || isParticipant) && isActiveBet;
           }).length;
 
           // Count joinable bets (not creator, not participant)


### PR DESCRIPTION
The Active tab badge was incorrectly counting bets with PENDING_RESOLUTION status. Now it only counts ACTIVE and LIVE bets, as PENDING_RESOLUTION bets should only appear on the Results tab.