### PR TITLE
Fix CustomAlert freezing issue on button press

### DIFF
--- a/src/components/ui/CustomAlert.tsx
+++ b/src/components/ui/CustomAlert.tsx
@@ -44,8 +44,15 @@ export const CustomAlert: React.FC<CustomAlertProps> = ({
   onDismiss,
 }) => {
   const handleButtonPress = (button: AlertButton) => {
-    button.onPress?.();
+    // Dismiss modal first for immediate UI feedback
     onDismiss?.();
+
+    // Then call the button callback (use setTimeout to ensure modal closes first)
+    if (button.onPress) {
+      setTimeout(() => {
+        button.onPress?.();
+      }, 100);
+    }
   };
 
   const handleBackdropPress = () => {
@@ -68,11 +75,7 @@ export const CustomAlert: React.FC<CustomAlertProps> = ({
         activeOpacity={1}
         onPress={handleBackdropPress}
       >
-        <TouchableOpacity
-          style={styles.alertContainer}
-          activeOpacity={1}
-          onPress={(e) => e.stopPropagation()}
-        >
+        <View style={styles.alertContainer}>
           <View style={styles.alertContent}>
             {/* Title */}
             <Text style={styles.title}>{title}</Text>
@@ -109,7 +112,7 @@ export const CustomAlert: React.FC<CustomAlertProps> = ({
               ))}
             </View>
           </View>
-        </TouchableOpacity>
+        </View>
       </TouchableOpacity>
     </Modal>
   );


### PR DESCRIPTION
- Change inner TouchableOpacity to View to prevent touch propagation issues
- Dismiss modal FIRST before calling button callback for immediate UI response
- Add setTimeout delay for button callbacks to ensure modal closes smoothly
- Fixes modal freezing when buttons are pressed

The previous implementation called button.onPress before dismissing, which could cause the modal to freeze if the callback had async operations or errors. Now the modal always dismisses immediately when a button is tapped.