### PR TITLE
Fix modal conflict in FileDisputeModal causing web freeze

### DIFF
--- a/src/components/ui/FileDisputeModal.tsx
+++ b/src/components/ui/FileDisputeModal.tsx
@@ -102,15 +102,19 @@ export const FileDisputeModal: React.FC<FileDisputeModalProps> = ({
       // Reset form
       setDescription('');
       setSelectedReason('INCORRECT_RESOLUTION');
-      onClose();
 
+      // Show success alert FIRST, then close modal when user clicks OK
       showAlert(
         'Dispute Filed',
         'Your dispute has been submitted and will be reviewed by an administrator. The payout is now on hold.',
-        [{ text: 'OK' }]
+        [{
+          text: 'OK',
+          onPress: () => {
+            onClose();
+            onDisputeFiled?.();
+          }
+        }]
       );
-
-      onDisputeFiled?.();
     } catch (error: any) {
       console.error('Error filing dispute:', error);
       showAlert(


### PR DESCRIPTION
- Show alert FIRST, then close modal in OK button callback
- Prevents modal stacking conflict on web platform
- FileDisputeModal now closes only after user dismisses success alert

The issue was calling onClose() immediately before showAlert(), which tries to close one modal and open another simultaneously. On web, this causes the page to freeze. The fix ensures alerts are shown while the modal is still open, then the modal closes when user clicks OK.