### PR TITLE
Fix bet card early end option for creator

### DIFF
--- a/src/components/betting/BetList.tsx
+++ b/src/components/betting/BetList.tsx
@@ -25,6 +25,9 @@ export interface BetListProps {
   onRefresh?: () => void;
   onLoadMore?: () => void;
   onBetPress?: (bet: Bet) => void;
+  onJoinBet?: (betId: string, side: string, amount: number) => void;
+  onInviteFriends?: (bet: Bet) => void;
+  onEndBet?: (bet: Bet) => void;
   emptyTitle?: string;
   emptyDescription?: string;
   showSearch?: boolean;
@@ -39,6 +42,9 @@ export const BetList: React.FC<BetListProps> = ({
   onRefresh,
   onLoadMore,
   onBetPress,
+  onJoinBet,
+  onInviteFriends,
+  onEndBet,
   emptyTitle = 'No bets found',
   emptyDescription = 'Check back later or create the first bet!',
   showSearch = true,
@@ -102,6 +108,9 @@ export const BetList: React.FC<BetListProps> = ({
     <BetCard
       bet={item}
       onPress={onBetPress}
+      onJoinBet={onJoinBet}
+      onInviteFriends={onInviteFriends}
+      onEndBet={onEndBet}
       variant={variant}
     />
   );

--- a/src/screens/BetsScreen.tsx
+++ b/src/screens/BetsScreen.tsx
@@ -569,6 +569,25 @@ export const BetsScreen: React.FC = () => {
     // Navigate to balance/wallet screen
   };
 
+  const handleEndBet = async (bet: Bet) => {
+    try {
+      // Update bet status to PENDING_RESOLUTION
+      await client.models.Bet.update({
+        id: bet.id,
+        status: 'PENDING_RESOLUTION',
+        updatedAt: new Date().toISOString(),
+      });
+
+      // Clear cache and refresh bets
+      clearBulkLoadingCache();
+      await fetchBets();
+
+      showAlert('Bet Ended', 'Your bet has been moved to pending resolution. You can now declare the winner.');
+    } catch (error) {
+      console.error('Error ending bet:', error);
+      showAlert('Error', 'Failed to end bet. Please try again.');
+    }
+  };
 
   // Removed - Header handles notifications internally now
 
@@ -687,6 +706,7 @@ export const BetsScreen: React.FC = () => {
                 setSelectedBetForInvite(bet);
                 setShowInviteModal(true);
               }}
+              onEndBet={handleEndBet}
             />
           ))
         ) : (


### PR DESCRIPTION
- Add handleEndBet function in BetsScreen that moves ACTIVE bets to PENDING_RESOLUTION
- Pass onEndBet prop to BetCard component to enable the "End Bet" button
- Update BetList component to support optional onEndBet, onJoinBet, and onInviteFriends callbacks
- End Bet button now appears for bet creators on ACTIVE bets
- Users can end bets before deadline expires, moving them to pending resolution

Fixes missing "End Bet" button that was implemented but not wired up.