### PR TITLE
Fix End Bet button not working on web - add missing showAlert import

### DIFF
--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -9,7 +9,6 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -23,6 +22,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { NotificationService } from '../../services/notificationService';
 import { TransactionService } from '../../services/transactionService';
 import { FileDisputeModal } from '../ui/FileDisputeModal';
+import { showAlert } from '../ui/CustomAlert';
 
 // Initialize GraphQL client
 const client = generateClient<Schema>();


### PR DESCRIPTION
- Remove unused Alert import from react-native (doesn't work on web)
- Add showAlert import from CustomAlert component
- Ensures cross-platform compatibility for End Bet confirmation dialog

The End Bet button was calling showAlert() without importing it, causing the button click to silently fail on web.