### PR TITLE
Fix: Exclude creator from bet acceptance requirement

### DIFF
--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -624,8 +624,8 @@ export const BetCard: React.FC<BetCardProps> = ({
                 </View>
               )}
 
-              {/* Accept Result Button - Only for participants who haven't accepted yet */}
-              {userParticipation.hasJoined && !acceptanceProgress.hasUserAccepted && (
+              {/* Accept Result Button - Only for NON-CREATOR participants who haven't accepted yet */}
+              {userParticipation.hasJoined && !acceptanceProgress.hasUserAccepted && bet.creatorId !== user?.userId && (
                 <TouchableOpacity
                   style={styles.acceptButton}
                   onPress={handleAcceptResult}


### PR DESCRIPTION
The creator's resolution IS their implicit acceptance, so they shouldn't need to explicitly accept the result.

Changes:
- checkIfAllAccepted() now filters out creator from participant count
- getAcceptanceProgress() excludes creator from total/accepted counts
- Accept button hidden from creator in BetCard UI
- Service layer validation prevents creator from accepting

Impact:
- In a 2-person bet (creator + 1 other), if the 1 participant accepts, bet closes early
- Creator sees acceptance progress but cannot accept themselves
- Progress shows "1 of 1 accepted" instead of "1 of 2" when creator is excluded