### PR TITLE
Fix scrolling under bottom navigation menu

### DIFF
--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -16,7 +16,7 @@ import {
   Modal,
   Image,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { generateClient } from 'aws-amplify/data';
 import { fetchUserAttributes } from 'aws-amplify/auth';
@@ -49,6 +49,7 @@ interface UserProfile extends User {
 
 export const AccountScreen: React.FC = () => {
   const { user, signOut } = useAuth();
+  const insets = useSafeAreaInsets();
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -394,6 +395,7 @@ export const AccountScreen: React.FC = () => {
 
       <ScrollView
         style={styles.content}
+        contentContainerStyle={{ paddingBottom: spacing.navigation.baseHeight + insets.bottom }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl

--- a/src/screens/BetsScreen.tsx
+++ b/src/screens/BetsScreen.tsx
@@ -16,7 +16,7 @@ import {
   RefreshControl,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { commonStyles, colors, spacing, typography, textStyles } from '../styles';
 import { Header } from '../components/ui/Header';
 import { BetCard } from '../components/betting/BetCard';
@@ -74,6 +74,7 @@ const transformAmplifyBet = (bet: any): Bet | null => {
 
 export const BetsScreen: React.FC = () => {
   const { user } = useAuth();
+  const insets = useSafeAreaInsets();
   const [bets, setBets] = useState<Bet[]>([]);
   const [betInvitations, setBetInvitations] = useState<BetInvitation[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -657,6 +658,7 @@ export const BetsScreen: React.FC = () => {
 
       <ScrollView
         style={styles.content}
+        contentContainerStyle={{ paddingBottom: spacing.navigation.baseHeight + insets.bottom }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl

--- a/src/screens/CreateBetScreen.tsx
+++ b/src/screens/CreateBetScreen.tsx
@@ -16,7 +16,7 @@ import {
   ActivityIndicator,
   Image,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
 import { generateClient } from 'aws-amplify/data';
 import { getCurrentUser } from 'aws-amplify/auth';
@@ -55,6 +55,7 @@ const client = generateClient<Schema>();
 
 export const CreateBetScreen: React.FC = () => {
   const { user } = useAuth();
+  const insets = useSafeAreaInsets();
   const { checkedInEvent } = useEventCheckIn();
   const scrollRef = React.useRef<ScrollView | null>(null);
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
@@ -554,7 +555,7 @@ export const CreateBetScreen: React.FC = () => {
         </View>
       )}
 
-      <ScrollView ref={scrollRef} style={styles.content} showsVerticalScrollIndicator={false}>
+      <ScrollView ref={scrollRef} style={styles.content} contentContainerStyle={{ paddingBottom: spacing.navigation.baseHeight + insets.bottom }} showsVerticalScrollIndicator={false}>
         {/* Bet Templates Section */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>CHOOSE BET TYPE</Text>

--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -15,7 +15,7 @@ import {
   RefreshControl,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { colors, commonStyles, textStyles, spacing, typography } from '../styles';
@@ -115,6 +115,7 @@ const mockLiveBets: Bet[] = [
 
 export const LiveEventsScreen: React.FC = () => {
   const { user } = useAuth();
+  const insets = useSafeAreaInsets();
   const [liveBets, setLiveBets] = useState<Bet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -307,6 +308,7 @@ export const LiveEventsScreen: React.FC = () => {
       
       <ScrollView
         style={styles.content}
+        contentContainerStyle={{ paddingBottom: spacing.navigation.baseHeight + insets.bottom }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl

--- a/src/screens/ResolveScreen.tsx
+++ b/src/screens/ResolveScreen.tsx
@@ -13,7 +13,7 @@ import {
   ActivityIndicator,
   RefreshControl,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { colors, commonStyles, textStyles, spacing, typography } from '../styles';
@@ -72,6 +72,7 @@ const transformAmplifyBet = (bet: any): Bet | null => {
 
 export const ResolveScreen: React.FC = () => {
   const { user } = useAuth();
+  const insets = useSafeAreaInsets();
   const [pendingBets, setPendingBets] = useState<Bet[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isResolving, setIsResolving] = useState<string | null>(null);
@@ -466,6 +467,7 @@ export const ResolveScreen: React.FC = () => {
 
       <ScrollView
         style={styles.content}
+        contentContainerStyle={{ paddingBottom: spacing.navigation.baseHeight + insets.bottom }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl

--- a/src/styles/spacing.ts
+++ b/src/styles/spacing.ts
@@ -72,7 +72,8 @@ export const spacing = {
     padding: 16,    // Header horizontal padding
   },
   navigation: {
-    height: 80,     // Bottom tab navigation height
+    height: 80,     // Bottom tab navigation height (legacy)
+    baseHeight: 85, // Bottom tab bar base height (minHeight from TabBar component)
     padding: 12,    // Tab padding
   },
   


### PR DESCRIPTION
Problem:
- When mobile browser URL bar disappears, viewport expands and content can scroll under the bottom tab bar
- Screens only used SafeAreaView with edges=['top'], leaving bottom edge unprotected
- ScrollViews had no bottom padding to account for tab bar height

Solution:
- Added spacing.navigation.baseHeight constant (85px) matching TabBar minHeight
- Updated all main tab screens to use useSafeAreaInsets hook
- Added contentContainerStyle with paddingBottom to all ScrollViews: paddingBottom = baseHeight (85px) + insets.bottom (safe area)
- This ensures content never scrolls under the tab bar regardless of viewport changes

Changed files:
- src/styles/spacing.ts: Added navigation.baseHeight constant
- src/screens/BetsScreen.tsx: Added bottom padding to ScrollView
- src/screens/LiveEventsScreen.tsx: Added bottom padding to ScrollView
- src/screens/ResolveScreen.tsx: Added bottom padding to ScrollView
- src/screens/CreateBetScreen.tsx: Added bottom padding to ScrollView
- src/screens/AccountScreen.tsx: Added bottom padding to ScrollView