### PR TITLE
Build out about us page with legal docs

### DIFF
--- a/src/screens/AboutScreen.tsx
+++ b/src/screens/AboutScreen.tsx
@@ -3,18 +3,26 @@
  * App version and legal information
  */
 
-import React from 'react';
-import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Modal } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { colors, spacing, textStyles, typography } from '../styles';
 import { ModalHeader } from '../components/ui/ModalHeader';
+import { PrivacyPolicyScreen } from './PrivacyPolicyScreen';
+import { TermsOfServiceScreen } from './TermsOfServiceScreen';
+import { CommunityGuidelinesScreen } from './CommunityGuidelinesScreen';
+import { OpenSourceLicensesScreen } from './OpenSourceLicensesScreen';
 
 interface AboutScreenProps {
   onClose: () => void;
 }
 
 export const AboutScreen: React.FC<AboutScreenProps> = ({ onClose }) => {
+  const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(false);
+  const [showTermsOfService, setShowTermsOfService] = useState(false);
+  const [showCommunityGuidelines, setShowCommunityGuidelines] = useState(false);
+  const [showOpenSourceLicenses, setShowOpenSourceLicenses] = useState(false);
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ModalHeader title="About" onClose={onClose} />
@@ -34,50 +42,50 @@ export const AboutScreen: React.FC<AboutScreenProps> = ({ onClose }) => {
         <View style={styles.section}>
           <TouchableOpacity
             style={styles.linkItem}
-            onPress={() => Linking.openURL('https://github.com/anthropics/claude-code')}
+            onPress={() => setShowTermsOfService(true)}
             activeOpacity={0.7}
           >
             <View style={styles.linkItemLeft}>
               <Ionicons name="document-text-outline" size={22} color={colors.textSecondary} />
               <Text style={styles.linkItemText}>Terms of Service</Text>
             </View>
-            <Ionicons name="open-outline" size={18} color={colors.textMuted} />
+            <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />
           </TouchableOpacity>
 
           <TouchableOpacity
             style={styles.linkItem}
-            onPress={() => Linking.openURL('https://github.com/anthropics/claude-code')}
+            onPress={() => setShowPrivacyPolicy(true)}
             activeOpacity={0.7}
           >
             <View style={styles.linkItemLeft}>
               <Ionicons name="shield-checkmark-outline" size={22} color={colors.textSecondary} />
               <Text style={styles.linkItemText}>Privacy Policy</Text>
             </View>
-            <Ionicons name="open-outline" size={18} color={colors.textMuted} />
+            <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />
           </TouchableOpacity>
 
           <TouchableOpacity
             style={styles.linkItem}
-            onPress={() => Linking.openURL('https://github.com/anthropics/claude-code')}
+            onPress={() => setShowCommunityGuidelines(true)}
             activeOpacity={0.7}
           >
             <View style={styles.linkItemLeft}>
-              <Ionicons name="help-circle-outline" size={22} color={colors.textSecondary} />
+              <Ionicons name="people-outline" size={22} color={colors.textSecondary} />
               <Text style={styles.linkItemText}>Community Guidelines</Text>
             </View>
-            <Ionicons name="open-outline" size={18} color={colors.textMuted} />
+            <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />
           </TouchableOpacity>
 
           <TouchableOpacity
             style={styles.linkItem}
-            onPress={() => Linking.openURL('https://github.com/anthropics/claude-code')}
+            onPress={() => setShowOpenSourceLicenses(true)}
             activeOpacity={0.7}
           >
             <View style={styles.linkItemLeft}>
-              <Ionicons name="logo-github" size={22} color={colors.textSecondary} />
-              <Text style={styles.linkItemText}>Open Source</Text>
+              <Ionicons name="code-slash-outline" size={22} color={colors.textSecondary} />
+              <Text style={styles.linkItemText}>Open Source Licenses</Text>
             </View>
-            <Ionicons name="open-outline" size={18} color={colors.textMuted} />
+            <Ionicons name="chevron-forward" size={18} color={colors.textMuted} />
           </TouchableOpacity>
         </View>
 
@@ -95,10 +103,47 @@ export const AboutScreen: React.FC<AboutScreenProps> = ({ onClose }) => {
             Made with ❤️ for peer-to-peer betting
           </Text>
           <Text style={styles.copyright}>
-            © 2025 SideBet. All rights reserved.
+            © 2025 SideBet LLC. All rights reserved.
           </Text>
         </View>
       </ScrollView>
+
+      {/* Legal Pages Modals */}
+      <Modal
+        visible={showTermsOfService}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowTermsOfService(false)}
+      >
+        <TermsOfServiceScreen onClose={() => setShowTermsOfService(false)} />
+      </Modal>
+
+      <Modal
+        visible={showPrivacyPolicy}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowPrivacyPolicy(false)}
+      >
+        <PrivacyPolicyScreen onClose={() => setShowPrivacyPolicy(false)} />
+      </Modal>
+
+      <Modal
+        visible={showCommunityGuidelines}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowCommunityGuidelines(false)}
+      >
+        <CommunityGuidelinesScreen onClose={() => setShowCommunityGuidelines(false)} />
+      </Modal>
+
+      <Modal
+        visible={showOpenSourceLicenses}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowOpenSourceLicenses(false)}
+      >
+        <OpenSourceLicensesScreen onClose={() => setShowOpenSourceLicenses(false)} />
+      </Modal>
     </SafeAreaView>
   );
 };

--- a/src/screens/CommunityGuidelinesScreen.tsx
+++ b/src/screens/CommunityGuidelinesScreen.tsx
@@ -1,0 +1,306 @@
+/**
+ * Community Guidelines Screen
+ * Conduct rules and betting ethics for SideBet
+ */
+
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, spacing, textStyles, typography } from '../styles';
+import { ModalHeader } from '../components/ui/ModalHeader';
+
+interface CommunityGuidelinesScreenProps {
+  onClose: () => void;
+}
+
+export const CommunityGuidelinesScreen: React.FC<CommunityGuidelinesScreenProps> = ({ onClose }) => {
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ModalHeader title="Community Guidelines" onClose={onClose} />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.effectiveDate}>Effective Date: January 1, 2025</Text>
+          <Text style={styles.intro}>
+            SideBet is a platform for friendly, peer-to-peer betting among friends. These Community Guidelines help ensure a safe, fair, and enjoyable experience for everyone.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>1. Core Principles</Text>
+          <Text style={styles.paragraph}>
+            Our community is built on trust, fairness, and respect. We expect all users to:
+          </Text>
+          <Text style={styles.bulletPoint}>• Act with honesty and integrity</Text>
+          <Text style={styles.bulletPoint}>• Treat other users with respect and kindness</Text>
+          <Text style={styles.bulletPoint}>• Honor your betting commitments</Text>
+          <Text style={styles.bulletPoint}>• Resolve disputes fairly and constructively</Text>
+          <Text style={styles.bulletPoint}>• Follow all applicable laws and regulations</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>2. Fair Betting Practices</Text>
+
+          <Text style={styles.subsectionTitle}>Creating Bets</Text>
+          <Text style={styles.bulletPoint}>• Create bets with clear, unambiguous terms</Text>
+          <Text style={styles.bulletPoint}>• Ensure bet outcomes can be objectively determined</Text>
+          <Text style={styles.bulletPoint}>• Do not create bets designed to deceive or mislead</Text>
+          <Text style={styles.bulletPoint}>• Set reasonable expiration dates</Text>
+          <Text style={styles.bulletPoint}>• Be available to resolve bets promptly after outcomes are known</Text>
+
+          <Text style={styles.subsectionTitle}>Joining Bets</Text>
+          <Text style={styles.bulletPoint}>• Only join bets you understand and can afford</Text>
+          <Text style={styles.bulletPoint}>• Read bet terms carefully before committing</Text>
+          <Text style={styles.bulletPoint}>• Do not attempt to manipulate bet outcomes</Text>
+          <Text style={styles.bulletPoint}>• Honor your commitment once you join a bet</Text>
+
+          <Text style={styles.subsectionTitle}>Resolving Bets</Text>
+          <Text style={styles.bulletPoint}>• Resolve bets honestly based on actual outcomes</Text>
+          <Text style={styles.bulletPoint}>• Do not delay resolution to avoid paying winners</Text>
+          <Text style={styles.bulletPoint}>• Provide evidence if requested to support resolution</Text>
+          <Text style={styles.bulletPoint}>• Cancel bets only when appropriate (e.g., event cancelled)</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>3. Prohibited Bet Types</Text>
+          <Text style={styles.paragraph}>
+            The following types of bets are strictly prohibited on SideBet:
+          </Text>
+          <Text style={styles.bulletPoint}>• Bets involving illegal activities or criminal conduct</Text>
+          <Text style={styles.bulletPoint}>• Bets on violence, harm, or injury to people or animals</Text>
+          <Text style={styles.bulletPoint}>• Bets involving minors or their activities</Text>
+          <Text style={styles.bulletPoint}>• Bets on the death, illness, or suffering of individuals</Text>
+          <Text style={styles.bulletPoint}>• Bets that violate privacy or involve harassment</Text>
+          <Text style={styles.bulletPoint}>• Bets on regulated professional sports events (where prohibited by law)</Text>
+          <Text style={styles.bulletPoint}>• Bets where the outcome can be controlled by a participant</Text>
+          <Text style={styles.bulletPoint}>• Bets involving discriminatory or hateful content</Text>
+          <Text style={styles.bulletPoint}>• Bets designed to circumvent terms of service</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>4. Acceptable Bet Examples</Text>
+          <Text style={styles.paragraph}>
+            SideBet is designed for friendly, personal wagers such as:
+          </Text>
+          <Text style={styles.bulletPoint}>• Sports outcomes among friends (where legally permitted)</Text>
+          <Text style={styles.bulletPoint}>• Personal challenges (weight loss goals, fitness milestones)</Text>
+          <Text style={styles.bulletPoint}>• Game scores or tournament brackets</Text>
+          <Text style={styles.bulletPoint}>• Movie box office predictions</Text>
+          <Text style={styles.bulletPoint}>• Award show winners or nominees</Text>
+          <Text style={styles.bulletPoint}>• Weather conditions or temperature predictions</Text>
+          <Text style={styles.bulletPoint}>• Friendly competitions among friends</Text>
+          <Text style={styles.paragraph}>
+            Remember: Bets must comply with all local, state, and federal laws.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>5. Respectful Conduct</Text>
+          <Text style={styles.paragraph}>
+            We have zero tolerance for:
+          </Text>
+          <Text style={styles.bulletPoint}>• Harassment, bullying, or threatening behavior</Text>
+          <Text style={styles.bulletPoint}>• Hate speech or discriminatory language</Text>
+          <Text style={styles.bulletPoint}>• Sexually explicit or inappropriate content</Text>
+          <Text style={styles.bulletPoint}>• Impersonation of others</Text>
+          <Text style={styles.bulletPoint}>• Spam or unsolicited commercial messages</Text>
+          <Text style={styles.bulletPoint}>• Sharing private information without consent</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>6. Fraud and Cheating</Text>
+          <Text style={styles.paragraph}>
+            The following behaviors will result in immediate account termination:
+          </Text>
+          <Text style={styles.bulletPoint}>• Creating fake accounts or profiles</Text>
+          <Text style={styles.bulletPoint}>• Using multiple accounts to circumvent restrictions</Text>
+          <Text style={styles.bulletPoint}>• Providing fraudulent payment information</Text>
+          <Text style={styles.bulletPoint}>• Manipulating bet outcomes through collusion</Text>
+          <Text style={styles.bulletPoint}>• Exploiting bugs or system vulnerabilities</Text>
+          <Text style={styles.bulletPoint}>• Money laundering or using SideBet for illegal financial activity</Text>
+          <Text style={styles.bulletPoint}>• Attempting to defraud other users or SideBet</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>7. Payment and Financial Conduct</Text>
+          <Text style={styles.paragraph}>
+            All users must:
+          </Text>
+          <Text style={styles.bulletPoint}>• Provide accurate payment information</Text>
+          <Text style={styles.bulletPoint}>• Only deposit funds you own and have authorization to use</Text>
+          <Text style={styles.bulletPoint}>• Not attempt to reverse or dispute legitimate transactions</Text>
+          <Text style={styles.bulletPoint}>• Maintain sufficient balance for active bets</Text>
+          <Text style={styles.bulletPoint}>• Comply with all tax reporting obligations in your jurisdiction</Text>
+          <Text style={styles.bulletPoint}>• Not use SideBet for commercial betting or professional gambling</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>8. Dispute Resolution</Text>
+          <Text style={styles.paragraph}>
+            If a dispute arises:
+          </Text>
+          <Text style={styles.bulletPoint}>• Communicate respectfully with other participants</Text>
+          <Text style={styles.bulletPoint}>• Provide evidence to support your position</Text>
+          <Text style={styles.bulletPoint}>• Be willing to compromise when appropriate</Text>
+          <Text style={styles.bulletPoint}>• Accept that bet creators have final resolution authority</Text>
+          <Text style={styles.bulletPoint}>• Contact support if you believe a user violated guidelines</Text>
+          <Text style={styles.paragraph}>
+            Remember: SideBet is for friendly betting. Choose your betting partners wisely and bet responsibly.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>9. Responsible Betting</Text>
+          <Text style={styles.paragraph}>
+            We encourage all users to bet responsibly:
+          </Text>
+          <Text style={styles.bulletPoint}>• Only bet amounts you can afford to lose</Text>
+          <Text style={styles.bulletPoint}>• Set personal limits on betting activity</Text>
+          <Text style={styles.bulletPoint}>• Do not chase losses with larger bets</Text>
+          <Text style={styles.bulletPoint}>• Take breaks if betting becomes stressful</Text>
+          <Text style={styles.bulletPoint}>• Seek help if you develop problematic betting behaviors</Text>
+          <Text style={styles.paragraph}>
+            If you're concerned about your betting habits, please reach out to support or visit the National Council on Problem Gambling at ncpgambling.org.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>10. Privacy and Data Protection</Text>
+          <Text style={styles.paragraph}>
+            Respect the privacy of other users:
+          </Text>
+          <Text style={styles.bulletPoint}>• Do not share screenshots of private conversations</Text>
+          <Text style={styles.bulletPoint}>• Do not collect or store other users' personal information</Text>
+          <Text style={styles.bulletPoint}>• Do not use SideBet data for commercial purposes</Text>
+          <Text style={styles.bulletPoint}>• Report suspected privacy violations to support</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>11. Reporting Violations</Text>
+          <Text style={styles.paragraph}>
+            If you encounter behavior that violates these guidelines:
+          </Text>
+          <Text style={styles.bulletPoint}>• Contact us through the Support section in the app</Text>
+          <Text style={styles.bulletPoint}>• Provide specific details and evidence when possible</Text>
+          <Text style={styles.bulletPoint}>• Do not engage with or retaliate against violators</Text>
+          <Text style={styles.bulletPoint}>• Allow our team time to investigate and respond</Text>
+          <Text style={styles.paragraph}>
+            We take all reports seriously and will investigate violations promptly.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>12. Consequences for Violations</Text>
+          <Text style={styles.paragraph}>
+            Violations of these Community Guidelines may result in:
+          </Text>
+          <Text style={styles.bulletPoint}>• Warning and educational guidance</Text>
+          <Text style={styles.bulletPoint}>• Temporary suspension of account privileges</Text>
+          <Text style={styles.bulletPoint}>• Permanent account termination</Text>
+          <Text style={styles.bulletPoint}>• Forfeiture of account balance for serious violations</Text>
+          <Text style={styles.bulletPoint}>• Legal action for fraudulent or illegal activity</Text>
+          <Text style={styles.paragraph}>
+            The severity of consequences depends on the nature and frequency of violations. We reserve the right to take action at our discretion to protect our community.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>13. Updates to Guidelines</Text>
+          <Text style={styles.paragraph}>
+            We may update these Community Guidelines from time to time to address new issues or improve clarity. Continued use of SideBet after updates constitutes acceptance of the revised guidelines.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>14. Contact Us</Text>
+          <Text style={styles.paragraph}>
+            If you have questions about these Community Guidelines or need to report a violation, please contact us through the Support section in the app.
+          </Text>
+          <Text style={styles.paragraph}>
+            SideBet LLC{'\n'}
+            Community Guidelines Inquiries
+          </Text>
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Thank you for being a responsible member of the SideBet community!
+          </Text>
+          <Text style={[styles.footerText, { marginTop: spacing.sm }]}>
+            © 2025 SideBet LLC. All rights reserved.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  effectiveDate: {
+    ...textStyles.label,
+    color: colors.textMuted,
+    marginBottom: spacing.sm,
+  },
+  intro: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+  },
+  section: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  sectionTitle: {
+    ...textStyles.h4,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.bold,
+    marginBottom: spacing.md,
+  },
+  subsectionTitle: {
+    ...textStyles.button,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  paragraph: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.sm,
+  },
+  bulletPoint: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.xs / 2,
+    paddingLeft: spacing.sm,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  footerText: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/OpenSourceLicensesScreen.tsx
+++ b/src/screens/OpenSourceLicensesScreen.tsx
@@ -1,0 +1,360 @@
+/**
+ * Open Source Licenses Screen
+ * Attribution for open source software used in SideBet
+ */
+
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Linking } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { colors, spacing, textStyles, typography } from '../styles';
+import { ModalHeader } from '../components/ui/ModalHeader';
+
+interface OpenSourceLicensesScreenProps {
+  onClose: () => void;
+}
+
+interface LicenseProps {
+  name: string;
+  version: string;
+  license: string;
+  description: string;
+  url?: string;
+}
+
+const License: React.FC<LicenseProps> = ({ name, version, license, description, url }) => {
+  return (
+    <View style={styles.licenseItem}>
+      <View style={styles.licenseHeader}>
+        <Text style={styles.licenseName}>{name}</Text>
+        <Text style={styles.licenseVersion}>v{version}</Text>
+      </View>
+      <Text style={styles.licenseType}>{license}</Text>
+      <Text style={styles.licenseDescription}>{description}</Text>
+      {url && (
+        <TouchableOpacity
+          style={styles.linkButton}
+          onPress={() => Linking.openURL(url)}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.linkButtonText}>View License</Text>
+          <Ionicons name="open-outline" size={14} color={colors.primary} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+export const OpenSourceLicensesScreen: React.FC<OpenSourceLicensesScreenProps> = ({ onClose }) => {
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ModalHeader title="Open Source Licenses" onClose={onClose} />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.intro}>
+            SideBet is built with love using open source software. We are grateful to the developers and communities who make these projects possible.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Core Technologies</Text>
+
+          <License
+            name="React Native"
+            version="0.76.9"
+            license="MIT License"
+            description="A framework for building native apps using React"
+            url="https://github.com/facebook/react-native/blob/main/LICENSE"
+          />
+
+          <License
+            name="React"
+            version="18.3.1"
+            license="MIT License"
+            description="A JavaScript library for building user interfaces"
+            url="https://github.com/facebook/react/blob/main/LICENSE"
+          />
+
+          <License
+            name="Expo"
+            version="52.0.0"
+            license="MIT License"
+            description="An open-source platform for making universal native apps"
+            url="https://github.com/expo/expo/blob/main/LICENSE"
+          />
+
+          <License
+            name="TypeScript"
+            version="5.8.3"
+            license="Apache License 2.0"
+            description="A typed superset of JavaScript that compiles to plain JavaScript"
+            url="https://github.com/microsoft/TypeScript/blob/main/LICENSE.txt"
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Backend & Cloud Services</Text>
+
+          <License
+            name="AWS Amplify"
+            version="6.15.4"
+            license="Apache License 2.0"
+            description="A set of tools and services for building scalable mobile and web applications"
+            url="https://github.com/aws-amplify/amplify-js/blob/main/LICENSE"
+          />
+
+          <License
+            name="AWS CDK"
+            version="2.138.0"
+            license="Apache License 2.0"
+            description="AWS Cloud Development Kit for defining cloud infrastructure"
+            url="https://github.com/aws/aws-cdk/blob/main/LICENSE"
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Navigation & UI</Text>
+
+          <License
+            name="React Navigation"
+            version="7.1.17"
+            license="MIT License"
+            description="Routing and navigation for React Native apps"
+            url="https://github.com/react-navigation/react-navigation/blob/main/packages/core/LICENSE"
+          />
+
+          <License
+            name="React Native Safe Area Context"
+            version="4.12.0"
+            license="MIT License"
+            description="A flexible way to handle safe area insets in React Native"
+            url="https://github.com/th3rdwave/react-native-safe-area-context/blob/main/LICENSE"
+          />
+
+          <License
+            name="React Native Gesture Handler"
+            version="2.20.2"
+            license="MIT License"
+            description="Declarative API exposing native platform touch and gesture system"
+            url="https://github.com/software-mansion/react-native-gesture-handler/blob/main/LICENSE"
+          />
+
+          <License
+            name="React Native SVG"
+            version="15.8.0"
+            license="MIT License"
+            description="SVG library for React Native"
+            url="https://github.com/software-mansion/react-native-svg/blob/main/LICENSE"
+          />
+
+          <License
+            name="Expo Vector Icons"
+            version="Included with Expo"
+            license="MIT License"
+            description="Built-in support for popular icon fonts and the tooling to create custom icon sets"
+            url="https://github.com/expo/vector-icons/blob/master/LICENSE"
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Utilities & Features</Text>
+
+          <License
+            name="Expo Notifications"
+            version="0.29.14"
+            license="MIT License"
+            description="Provides an API to fetch push notification tokens and handle incoming notifications"
+            url="https://github.com/expo/expo/blob/main/LICENSE"
+          />
+
+          <License
+            name="Expo Image Picker"
+            version="16.0.6"
+            license="MIT License"
+            description="Provides access to the system's UI for selecting images and videos"
+            url="https://github.com/expo/expo/blob/main/LICENSE"
+          />
+
+          <License
+            name="React Native Async Storage"
+            version="1.23.1"
+            license="MIT License"
+            description="An asynchronous, persistent, key-value storage system for React Native"
+            url="https://github.com/react-native-async-storage/async-storage/blob/main/LICENSE"
+          />
+
+          <License
+            name="React Native Toast Message"
+            version="2.3.3"
+            license="MIT License"
+            description="Animated toast message component for React Native"
+            url="https://github.com/calintamas/react-native-toast-message/blob/main/LICENSE"
+          />
+
+          <License
+            name="React Native QRCode SVG"
+            version="6.3.15"
+            license="MIT License"
+            description="QR code generator for React Native"
+            url="https://github.com/awesomejerry/react-native-qrcode-svg/blob/master/LICENSE"
+          />
+
+          <License
+            name="libphonenumber-js"
+            version="1.12.26"
+            license="MIT License"
+            description="A JavaScript port of Google's libphonenumber library"
+            url="https://github.com/catamphetamine/libphonenumber-js/blob/master/LICENSE"
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Development Tools</Text>
+
+          <License
+            name="ESLint"
+            version="8.57.0"
+            license="MIT License"
+            description="A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript"
+            url="https://github.com/eslint/eslint/blob/main/LICENSE"
+          />
+
+          <License
+            name="Babel"
+            version="7.20.0"
+            license="MIT License"
+            description="A JavaScript compiler that converts modern JavaScript into backwards compatible versions"
+            url="https://github.com/babel/babel/blob/main/LICENSE"
+          />
+        </View>
+
+        <View style={styles.licenseNotice}>
+          <Text style={styles.noticeTitle}>License Information</Text>
+          <Text style={styles.noticeText}>
+            The MIT License and Apache License 2.0 are permissive open source licenses that allow for reuse with minimal restrictions. All dependencies listed above retain their original licenses and copyrights.
+          </Text>
+          <Text style={styles.noticeText}>
+            For complete license texts and additional attributions, please visit the linked repositories above or contact us through the Support section.
+          </Text>
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Thank you to all open source contributors!
+          </Text>
+          <Text style={[styles.footerText, { marginTop: spacing.sm }]}>
+            © 2025 SideBet LLC. All rights reserved.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  intro: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+  },
+  section: {
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  sectionTitle: {
+    ...textStyles.h4,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.bold,
+    paddingHorizontal: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  licenseItem: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.divider,
+  },
+  licenseHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs / 2,
+  },
+  licenseName: {
+    ...textStyles.button,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    flex: 1,
+  },
+  licenseVersion: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    fontFamily: typography.fontFamily.mono,
+  },
+  licenseType: {
+    ...textStyles.label,
+    color: colors.primary,
+    marginBottom: spacing.xs / 2,
+  },
+  licenseDescription: {
+    ...textStyles.bodySmall,
+    color: colors.textSecondary,
+    lineHeight: 18,
+    marginBottom: spacing.xs,
+  },
+  linkButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing.xs / 2,
+  },
+  linkButtonText: {
+    ...textStyles.caption,
+    color: colors.primary,
+    marginRight: spacing.xs / 2,
+  },
+  licenseNotice: {
+    backgroundColor: colors.surface,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    marginTop: spacing.md,
+  },
+  noticeTitle: {
+    ...textStyles.h4,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    marginBottom: spacing.sm,
+  },
+  noticeText: {
+    ...textStyles.bodySmall,
+    color: colors.textSecondary,
+    lineHeight: 20,
+    marginBottom: spacing.sm,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  footerText: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/PrivacyPolicyScreen.tsx
+++ b/src/screens/PrivacyPolicyScreen.tsx
@@ -1,0 +1,253 @@
+/**
+ * Privacy Policy Screen
+ * GDPR-compliant privacy policy for SideBet
+ */
+
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, spacing, textStyles, typography } from '../styles';
+import { ModalHeader } from '../components/ui/ModalHeader';
+
+interface PrivacyPolicyScreenProps {
+  onClose: () => void;
+}
+
+export const PrivacyPolicyScreen: React.FC<PrivacyPolicyScreenProps> = ({ onClose }) => {
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ModalHeader title="Privacy Policy" onClose={onClose} />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.effectiveDate}>Effective Date: January 1, 2025</Text>
+          <Text style={styles.intro}>
+            SideBet LLC ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our mobile application.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>1. Information We Collect</Text>
+
+          <Text style={styles.subsectionTitle}>Personal Information</Text>
+          <Text style={styles.paragraph}>
+            We collect information that you provide directly to us, including:
+          </Text>
+          <Text style={styles.bulletPoint}>• Email address (required for account creation)</Text>
+          <Text style={styles.bulletPoint}>• Display name (optional)</Text>
+          <Text style={styles.bulletPoint}>• Profile picture (optional)</Text>
+          <Text style={styles.bulletPoint}>• Payment information (Venmo username, email, or phone number)</Text>
+
+          <Text style={styles.subsectionTitle}>Betting Activity Data</Text>
+          <Text style={styles.paragraph}>
+            We automatically collect information about your betting activities:
+          </Text>
+          <Text style={styles.bulletPoint}>• Bets created and joined</Text>
+          <Text style={styles.bulletPoint}>• Bet outcomes and resolutions</Text>
+          <Text style={styles.bulletPoint}>• Transaction history (deposits, withdrawals, winnings)</Text>
+          <Text style={styles.bulletPoint}>• Account balance and payment methods</Text>
+          <Text style={styles.bulletPoint}>• Friend connections and interactions</Text>
+
+          <Text style={styles.subsectionTitle}>Device and Usage Information</Text>
+          <Text style={styles.paragraph}>
+            We collect information about how you access and use the app:
+          </Text>
+          <Text style={styles.bulletPoint}>• Device type and operating system</Text>
+          <Text style={styles.bulletPoint}>• App version and settings</Text>
+          <Text style={styles.bulletPoint}>• Push notification tokens</Text>
+          <Text style={styles.bulletPoint}>• Log data and error reports</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>2. How We Use Your Information</Text>
+          <Text style={styles.paragraph}>
+            We use the information we collect to:
+          </Text>
+          <Text style={styles.bulletPoint}>• Provide, maintain, and improve our services</Text>
+          <Text style={styles.bulletPoint}>• Process and manage your bets and transactions</Text>
+          <Text style={styles.bulletPoint}>• Facilitate payments and withdrawals</Text>
+          <Text style={styles.bulletPoint}>• Send you notifications about bet activity and account updates</Text>
+          <Text style={styles.bulletPoint}>• Detect and prevent fraud, abuse, and security incidents</Text>
+          <Text style={styles.bulletPoint}>• Comply with legal obligations and enforce our Terms of Service</Text>
+          <Text style={styles.bulletPoint}>• Respond to your support requests and feedback</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>3. Information Sharing and Disclosure</Text>
+          <Text style={styles.paragraph}>
+            We do not sell your personal information. We may share your information in the following circumstances:
+          </Text>
+
+          <Text style={styles.subsectionTitle}>With Other Users</Text>
+          <Text style={styles.bulletPoint}>• Display name and profile picture are visible to friends and bet participants</Text>
+          <Text style={styles.bulletPoint}>• Betting activity is visible to other participants in the same bets</Text>
+
+          <Text style={styles.subsectionTitle}>Service Providers</Text>
+          <Text style={styles.bulletPoint}>• AWS (cloud hosting and database services)</Text>
+          <Text style={styles.bulletPoint}>• Expo (push notification delivery)</Text>
+          <Text style={styles.bulletPoint}>• Payment processors (for verifying Venmo transactions)</Text>
+
+          <Text style={styles.subsectionTitle}>Legal Requirements</Text>
+          <Text style={styles.paragraph}>
+            We may disclose your information if required by law, legal process, or to protect the rights, property, or safety of SideBet, our users, or others.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>4. Data Storage and Security</Text>
+          <Text style={styles.paragraph}>
+            Your data is stored securely using AWS Amplify and Amazon Web Services infrastructure:
+          </Text>
+          <Text style={styles.bulletPoint}>• Data is encrypted in transit using HTTPS/TLS</Text>
+          <Text style={styles.bulletPoint}>• Data is encrypted at rest in AWS databases</Text>
+          <Text style={styles.bulletPoint}>• Authentication is managed through AWS Cognito</Text>
+          <Text style={styles.bulletPoint}>• Access controls limit data access to authorized users only</Text>
+          <Text style={styles.paragraph}>
+            While we implement industry-standard security measures, no system is completely secure. You are responsible for maintaining the confidentiality of your account credentials.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>5. Your Privacy Rights</Text>
+          <Text style={styles.paragraph}>
+            Depending on your location, you may have the following rights:
+          </Text>
+          <Text style={styles.bulletPoint}>• Access: Request a copy of your personal data</Text>
+          <Text style={styles.bulletPoint}>• Correction: Update or correct inaccurate information</Text>
+          <Text style={styles.bulletPoint}>• Deletion: Request deletion of your account and data</Text>
+          <Text style={styles.bulletPoint}>• Portability: Receive your data in a machine-readable format</Text>
+          <Text style={styles.bulletPoint}>• Opt-out: Disable push notifications in app settings</Text>
+
+          <Text style={styles.paragraph}>
+            To exercise these rights, contact us through the Support section in the app. We will respond to your request within 30 days.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>6. Data Retention</Text>
+          <Text style={styles.paragraph}>
+            We retain your information for as long as your account is active or as needed to provide services. After account deletion:
+          </Text>
+          <Text style={styles.bulletPoint}>• Personal information is deleted within 90 days</Text>
+          <Text style={styles.bulletPoint}>• Transaction records may be retained for 7 years for legal compliance</Text>
+          <Text style={styles.bulletPoint}>• Aggregated, anonymized data may be retained indefinitely</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>7. Children's Privacy</Text>
+          <Text style={styles.paragraph}>
+            SideBet is only available to users 18 years of age or older. We do not knowingly collect information from anyone under 18. If we discover that a user under 18 has provided personal information, we will delete it immediately.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>8. International Data Transfers</Text>
+          <Text style={styles.paragraph}>
+            Your information may be transferred to and processed in countries other than your own. By using SideBet, you consent to the transfer of your information to the United States and other countries where our service providers operate.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>9. Third-Party Services</Text>
+          <Text style={styles.paragraph}>
+            SideBet integrates with third-party payment services (Venmo). We are not responsible for the privacy practices of these third parties. Please review their privacy policies before using their services.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>10. Changes to This Policy</Text>
+          <Text style={styles.paragraph}>
+            We may update this Privacy Policy from time to time. We will notify you of material changes by posting the new policy in the app and updating the "Effective Date" above. Your continued use of SideBet after changes constitutes acceptance of the updated policy.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>11. Contact Us</Text>
+          <Text style={styles.paragraph}>
+            If you have questions about this Privacy Policy or our data practices, please contact us through the Support section in the app.
+          </Text>
+          <Text style={styles.paragraph}>
+            SideBet LLC{'\n'}
+            Privacy Policy Inquiries
+          </Text>
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            © 2025 SideBet LLC. All rights reserved.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  effectiveDate: {
+    ...textStyles.label,
+    color: colors.textMuted,
+    marginBottom: spacing.sm,
+  },
+  intro: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+  },
+  section: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  sectionTitle: {
+    ...textStyles.h4,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.bold,
+    marginBottom: spacing.md,
+  },
+  subsectionTitle: {
+    ...textStyles.button,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  paragraph: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.sm,
+  },
+  bulletPoint: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.xs / 2,
+    paddingLeft: spacing.sm,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  footerText: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/TermsOfServiceScreen.tsx
+++ b/src/screens/TermsOfServiceScreen.tsx
@@ -1,0 +1,308 @@
+/**
+ * Terms of Service Screen
+ * Legal terms and conditions for SideBet
+ */
+
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { colors, spacing, textStyles, typography } from '../styles';
+import { ModalHeader } from '../components/ui/ModalHeader';
+
+interface TermsOfServiceScreenProps {
+  onClose: () => void;
+}
+
+export const TermsOfServiceScreen: React.FC<TermsOfServiceScreenProps> = ({ onClose }) => {
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <ModalHeader title="Terms of Service" onClose={onClose} />
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.effectiveDate}>Effective Date: January 1, 2025</Text>
+          <Text style={styles.intro}>
+            Welcome to SideBet. By accessing or using our mobile application, you agree to be bound by these Terms of Service. Please read them carefully.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>1. Acceptance of Terms</Text>
+          <Text style={styles.paragraph}>
+            By creating an account or using SideBet, you agree to these Terms of Service, our Privacy Policy, and our Community Guidelines. If you do not agree, you may not use our services.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>2. Eligibility</Text>
+          <Text style={styles.paragraph}>
+            You must be at least 18 years of age to use SideBet. By using the app, you represent and warrant that:
+          </Text>
+          <Text style={styles.bulletPoint}>• You are 18 years of age or older</Text>
+          <Text style={styles.bulletPoint}>• You have the legal capacity to enter into binding contracts</Text>
+          <Text style={styles.bulletPoint}>• You are not prohibited by law from using our services</Text>
+          <Text style={styles.bulletPoint}>• All information you provide is accurate and current</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>3. Account Registration and Security</Text>
+          <Text style={styles.paragraph}>
+            To use SideBet, you must create an account. You agree to:
+          </Text>
+          <Text style={styles.bulletPoint}>• Provide accurate and complete registration information</Text>
+          <Text style={styles.bulletPoint}>• Maintain the security of your account credentials</Text>
+          <Text style={styles.bulletPoint}>• Notify us immediately of any unauthorized access</Text>
+          <Text style={styles.bulletPoint}>• Be responsible for all activity under your account</Text>
+          <Text style={styles.bulletPoint}>• Not share your account with others</Text>
+          <Text style={styles.paragraph}>
+            We reserve the right to suspend or terminate accounts that violate these terms or engage in fraudulent activity.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>4. How SideBet Works</Text>
+          <Text style={styles.paragraph}>
+            SideBet is a peer-to-peer betting platform where users can create, join, and resolve friendly wagers with friends:
+          </Text>
+
+          <Text style={styles.subsectionTitle}>Creating Bets</Text>
+          <Text style={styles.bulletPoint}>• Users can create custom bets with two sides (e.g., Team A vs Team B)</Text>
+          <Text style={styles.bulletPoint}>• Bet creators set the amount and invite friends to participate</Text>
+          <Text style={styles.bulletPoint}>• All participants must agree to the bet terms before joining</Text>
+
+          <Text style={styles.subsectionTitle}>Joining Bets</Text>
+          <Text style={styles.bulletPoint}>• Users can join active bets created by friends</Text>
+          <Text style={styles.bulletPoint}>• Joining a bet deducts the bet amount from your account balance</Text>
+          <Text style={styles.bulletPoint}>• Once joined, bets cannot be cancelled unless the creator cancels the entire bet</Text>
+
+          <Text style={styles.subsectionTitle}>Bet Resolution</Text>
+          <Text style={styles.bulletPoint}>• Only the bet creator can determine the winning side</Text>
+          <Text style={styles.bulletPoint}>• Payouts are automatically distributed to winners</Text>
+          <Text style={styles.bulletPoint}>• SideBet does not charge fees or take a percentage of winnings</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>5. Account Balance and Transactions</Text>
+
+          <Text style={styles.subsectionTitle}>Deposits</Text>
+          <Text style={styles.bulletPoint}>• You can add funds to your account via Venmo</Text>
+          <Text style={styles.bulletPoint}>• All deposits require admin verification before being credited</Text>
+          <Text style={styles.bulletPoint}>• You must provide valid Venmo transaction details</Text>
+          <Text style={styles.bulletPoint}>• Fraudulent deposit attempts will result in account termination</Text>
+
+          <Text style={styles.subsectionTitle}>Withdrawals</Text>
+          <Text style={styles.bulletPoint}>• You can withdraw funds to your verified Venmo account</Text>
+          <Text style={styles.bulletPoint}>• Withdrawals are processed manually by our admin team</Text>
+          <Text style={styles.bulletPoint}>• Processing may take 1-5 business days</Text>
+          <Text style={styles.bulletPoint}>• Minimum withdrawal amount may apply</Text>
+
+          <Text style={styles.subsectionTitle}>Account Balance</Text>
+          <Text style={styles.bulletPoint}>• Your balance reflects available funds for betting</Text>
+          <Text style={styles.bulletPoint}>• Balances are held in your SideBet account, not with Venmo</Text>
+          <Text style={styles.bulletPoint}>• SideBet LLC maintains custody of all user funds</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>6. User Responsibilities</Text>
+          <Text style={styles.paragraph}>
+            You agree to use SideBet responsibly and in compliance with all applicable laws. You will not:
+          </Text>
+          <Text style={styles.bulletPoint}>• Use SideBet for illegal gambling or activities prohibited by law</Text>
+          <Text style={styles.bulletPoint}>• Create bets involving minors, illegal activities, or violence</Text>
+          <Text style={styles.bulletPoint}>• Engage in fraud, cheating, or manipulation of bet outcomes</Text>
+          <Text style={styles.bulletPoint}>• Harass, threaten, or abuse other users</Text>
+          <Text style={styles.bulletPoint}>• Attempt to gain unauthorized access to our systems</Text>
+          <Text style={styles.bulletPoint}>• Use automated systems or bots to interact with the app</Text>
+          <Text style={styles.bulletPoint}>• Create multiple accounts to circumvent restrictions</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>7. Dispute Resolution</Text>
+          <Text style={styles.paragraph}>
+            If a dispute arises regarding a bet outcome:
+          </Text>
+          <Text style={styles.bulletPoint}>• Users should first attempt to resolve disputes directly</Text>
+          <Text style={styles.bulletPoint}>• The bet creator has final authority on bet outcomes</Text>
+          <Text style={styles.bulletPoint}>• SideBet may mediate disputes at our discretion but is not obligated to do so</Text>
+          <Text style={styles.bulletPoint}>• Our decisions regarding disputes are final and binding</Text>
+          <Text style={styles.paragraph}>
+            SideBet is a platform for friendly betting and is not responsible for disputes between users.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>8. Intellectual Property</Text>
+          <Text style={styles.paragraph}>
+            All content, features, and functionality of SideBet are owned by SideBet LLC and are protected by copyright, trademark, and other intellectual property laws. You may not:
+          </Text>
+          <Text style={styles.bulletPoint}>• Copy, modify, or distribute our app or content</Text>
+          <Text style={styles.bulletPoint}>• Reverse engineer or decompile the app</Text>
+          <Text style={styles.bulletPoint}>• Use our trademarks or branding without permission</Text>
+          <Text style={styles.bulletPoint}>• Create derivative works based on our services</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>9. Disclaimer of Warranties</Text>
+          <Text style={styles.paragraph}>
+            SIDEBET IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND. WE DO NOT GUARANTEE THAT:
+          </Text>
+          <Text style={styles.bulletPoint}>• The app will be error-free or uninterrupted</Text>
+          <Text style={styles.bulletPoint}>• Defects will be corrected</Text>
+          <Text style={styles.bulletPoint}>• The app is free from viruses or harmful components</Text>
+          <Text style={styles.bulletPoint}>• Results obtained from using the app will be accurate or reliable</Text>
+          <Text style={styles.paragraph}>
+            You use SideBet at your own risk.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>10. Limitation of Liability</Text>
+          <Text style={styles.paragraph}>
+            TO THE MAXIMUM EXTENT PERMITTED BY LAW, SIDEBET LLC SHALL NOT BE LIABLE FOR:
+          </Text>
+          <Text style={styles.bulletPoint}>• Indirect, incidental, or consequential damages</Text>
+          <Text style={styles.bulletPoint}>• Loss of profits, data, or goodwill</Text>
+          <Text style={styles.bulletPoint}>• Damages arising from disputes between users</Text>
+          <Text style={styles.bulletPoint}>• Unauthorized access to your account or data</Text>
+          <Text style={styles.bulletPoint}>• Actions or omissions of third-party payment providers</Text>
+          <Text style={styles.paragraph}>
+            Our total liability shall not exceed the amount you paid to SideBet in the 12 months preceding the claim.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>11. Indemnification</Text>
+          <Text style={styles.paragraph}>
+            You agree to indemnify and hold harmless SideBet LLC, its officers, directors, employees, and agents from any claims, damages, losses, or expenses arising from:
+          </Text>
+          <Text style={styles.bulletPoint}>• Your violation of these Terms of Service</Text>
+          <Text style={styles.bulletPoint}>• Your use or misuse of the app</Text>
+          <Text style={styles.bulletPoint}>• Your violation of any law or rights of a third party</Text>
+          <Text style={styles.bulletPoint}>• Disputes with other users</Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>12. Termination</Text>
+          <Text style={styles.paragraph}>
+            We reserve the right to suspend or terminate your account at any time for:
+          </Text>
+          <Text style={styles.bulletPoint}>• Violation of these Terms of Service</Text>
+          <Text style={styles.bulletPoint}>• Fraudulent or illegal activity</Text>
+          <Text style={styles.bulletPoint}>• Abuse of other users or our systems</Text>
+          <Text style={styles.bulletPoint}>• Any reason at our sole discretion</Text>
+          <Text style={styles.paragraph}>
+            Upon termination, you may withdraw any remaining balance subject to verification. We are not liable for any losses resulting from account termination.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>13. Governing Law and Jurisdiction</Text>
+          <Text style={styles.paragraph}>
+            These Terms are governed by the laws of the United States. Any disputes shall be resolved in the appropriate courts, and you consent to personal jurisdiction in such courts.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>14. Changes to Terms</Text>
+          <Text style={styles.paragraph}>
+            We may modify these Terms of Service at any time. We will notify you of material changes by posting the updated terms in the app and updating the "Effective Date" above. Your continued use of SideBet after changes constitutes acceptance of the updated terms.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>15. Severability</Text>
+          <Text style={styles.paragraph}>
+            If any provision of these Terms is found to be unenforceable or invalid, that provision shall be modified to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>16. Contact Information</Text>
+          <Text style={styles.paragraph}>
+            If you have questions about these Terms of Service, please contact us through the Support section in the app.
+          </Text>
+          <Text style={styles.paragraph}>
+            SideBet LLC{'\n'}
+            Terms of Service Inquiries
+          </Text>
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            © 2025 SideBet LLC. All rights reserved.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  effectiveDate: {
+    ...textStyles.label,
+    color: colors.textMuted,
+    marginBottom: spacing.sm,
+  },
+  intro: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+  },
+  section: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  sectionTitle: {
+    ...textStyles.h4,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.bold,
+    marginBottom: spacing.md,
+  },
+  subsectionTitle: {
+    ...textStyles.button,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  paragraph: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.sm,
+  },
+  bulletPoint: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.xs / 2,
+    paddingLeft: spacing.sm,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  footerText: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
Created four in-app legal document screens following modal standards:
- Privacy Policy: GDPR-compliant privacy policy for SideBet LLC
- Terms of Service: Complete legal terms for 18+ users
- Community Guidelines: Betting conduct and acceptable use rules
- Open Source Licenses: Attribution for all major dependencies

Updated AboutScreen to open legal pages as in-app modals instead of external links. Changed icons to chevron-forward and updated copyright to reference SideBet LLC.

All screens follow MODAL_STANDARDS.md requirements:
- Use ModalHeader component with onClose callback
- presentationStyle="fullScreen" for proper rendering
- SafeAreaView with edges={['top']}
- Design system tokens for all styling
- Proper accessibility and contrast ratios

Benefits:
- No external dependencies or web hosting needed
- Works offline
- Consistent UX with rest of app
- Easy to maintain in version control
- Cross-platform compatibility