### PR TITLE
Fix login page background scrolling issue

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -202,6 +202,7 @@ const styles = StyleSheet.create({
   scrollContainer: {
     flexGrow: 1,
     justifyContent: 'center',
+    backgroundColor: colors.background,
   },
   container: {
     flex: 1,


### PR DESCRIPTION
Added backgroundColor to scrollContainer to prevent white space from showing when scrolling on the login page. The background color now extends throughout the entire scrollable area.