### PR TITLE
Fix squished profile picture uploads

### DIFF
--- a/src/components/onboarding/OnboardingProfilePictureStep.tsx
+++ b/src/components/onboarding/OnboardingProfilePictureStep.tsx
@@ -122,6 +122,7 @@ export const OnboardingProfilePictureStep: React.FC<OnboardingProfilePictureStep
                 key={profilePictureUrl}
                 source={{ uri: profilePictureUrl }}
                 style={styles.profileImage}
+                resizeMode="cover"
                 onLoadStart={() => {
                   // Only set loading if this is actually a new URL
                   if (loadedUrlRef.current !== profilePictureUrl) {

--- a/src/components/ui/AddFriendModal.tsx
+++ b/src/components/ui/AddFriendModal.tsx
@@ -247,7 +247,7 @@ export const AddFriendModal: React.FC<AddFriendModalProps> = ({
           {/* Avatar */}
           <View style={styles.avatarContainer}>
             {item.profilePictureUrl ? (
-              <Image source={{ uri: item.profilePictureUrl }} style={styles.avatar} />
+              <Image source={{ uri: item.profilePictureUrl }} style={styles.avatar} resizeMode="cover" />
             ) : (
               <View style={styles.avatarPlaceholder}>
                 <Text style={styles.avatarText}>{generateAvatarInitials(item)}</Text>

--- a/src/components/ui/BetInviteModal.tsx
+++ b/src/components/ui/BetInviteModal.tsx
@@ -300,7 +300,7 @@ export const BetInviteModal: React.FC<BetInviteModalProps> = ({
           {/* Avatar */}
           <View style={styles.avatarContainer}>
             {item.user.profilePictureUrl ? (
-              <Image source={{ uri: item.user.profilePictureUrl }} style={styles.avatar} />
+              <Image source={{ uri: item.user.profilePictureUrl }} style={styles.avatar} resizeMode="cover" />
             ) : (
               <View style={styles.avatarPlaceholder}>
                 <Text style={styles.avatarText}>{generateAvatarInitials(item.user)}</Text>

--- a/src/components/ui/FriendRequestsModal.tsx
+++ b/src/components/ui/FriendRequestsModal.tsx
@@ -269,7 +269,7 @@ export const FriendRequestsModal: React.FC<FriendRequestsModalProps> = ({
           {/* Avatar */}
           <View style={styles.avatarContainer}>
             {item.fromUser.profilePictureUrl ? (
-              <Image source={{ uri: item.fromUser.profilePictureUrl }} style={styles.avatar} />
+              <Image source={{ uri: item.fromUser.profilePictureUrl }} style={styles.avatar} resizeMode="cover" />
             ) : (
               <View style={styles.avatarPlaceholder}>
                 <Text style={styles.avatarText}>{generateAvatarInitials(item.fromUser)}</Text>

--- a/src/components/ui/ProfileEditor.tsx
+++ b/src/components/ui/ProfileEditor.tsx
@@ -129,7 +129,7 @@ export const ProfileEditor: React.FC<ProfileEditorProps> = ({
             disabled={isUploadingImage}
           >
             {profilePicture ? (
-              <Image source={{ uri: profilePicture }} style={styles.profileImage} />
+              <Image source={{ uri: profilePicture }} style={styles.profileImage} resizeMode="cover" />
             ) : (
               <View style={styles.placeholderImage}>
                 <Ionicons name="person" size={40} color={colors.textMuted} />

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -429,6 +429,7 @@ export const AccountScreen: React.FC = () => {
                 <Image
                   source={{ uri: userProfile.profilePictureUrl }}
                   style={styles.profileImage}
+                  resizeMode="cover"
                 />
               ) : (
                 <View style={styles.avatar}>

--- a/src/screens/CreateBetScreen.tsx
+++ b/src/screens/CreateBetScreen.tsx
@@ -802,7 +802,7 @@ export const CreateBetScreen: React.FC = () => {
                     activeOpacity={0.7}
                   >
                     {friend.profilePictureUrl ? (
-                      <Image source={{ uri: friend.profilePictureUrl }} style={styles.friendImage} />
+                      <Image source={{ uri: friend.profilePictureUrl }} style={styles.friendImage} resizeMode="cover" />
                     ) : (
                       <View style={[styles.friendPlaceholder, selectedFriends.has(friend.id) && styles.friendPlaceholderSelected]}>
                         <Text style={[styles.friendInitials, selectedFriends.has(friend.id) && styles.friendInitialsSelected]}>

--- a/src/screens/FriendsScreen.tsx
+++ b/src/screens/FriendsScreen.tsx
@@ -380,6 +380,7 @@ const FriendCard: React.FC<FriendCardProps> = ({
             <Image
               source={{ uri: friend.user.profilePictureUrl }}
               style={styles.friendAvatar}
+              resizeMode="cover"
             />
           ) : (
             <View style={styles.friendAvatarPlaceholder}>


### PR DESCRIPTION
Profile pictures were appearing squished when displayed because the Image components lacked a resizeMode property. React Native's default behavior can distort images when they don't match the container's aspect ratio.

Changes:
- Added resizeMode="cover" to all profile picture Image components
- Ensures images maintain their aspect ratio and fill circular containers
- Fixes display across all screens: Account, Friends, Profile Editor, Onboarding, Create Bet, Friend Requests, Add Friend, and Bet Invites

Files updated:
- src/screens/AccountScreen.tsx
- src/screens/FriendsScreen.tsx
- src/screens/CreateBetScreen.tsx
- src/components/ui/ProfileEditor.tsx
- src/components/ui/FriendRequestsModal.tsx
- src/components/ui/AddFriendModal.tsx
- src/components/ui/BetInviteModal.tsx
- src/components/onboarding/OnboardingProfilePictureStep.tsx