### PR TITLE
Handle Venmo fees in payment processing

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -406,7 +406,8 @@ const schema = a.schema({
         'ADMIN_ADJUSTMENT'  // Admin balance correction
       ]),
       status: a.enum(['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED', 'CANCELLED']),
-      amount: a.float().required(),
+      amount: a.float().required(), // Requested amount (what user intended to deposit/withdraw)
+      actualAmount: a.float(), // Actual amount received after fees (for deposits) or sent (for withdrawals)
       // Balance tracking
       balanceBefore: a.float().required(),
       balanceAfter: a.float().required(),

--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -280,6 +280,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
             {'\n'}3. Copy the transaction ID from Venmo
             {'\n'}4. Paste it below for verification
             {'\n'}5. Our team will verify and approve within 1-2 hours
+            {'\n'}{'\n'}Note: Venmo may charge fees. You'll be credited with the actual amount received.
           </Text>
         </View>
       </View>


### PR DESCRIPTION
- Add actualAmount field to Transaction model to store amount received after fees
- Add "Actual Amount Received" input field in admin approval modal
- Display calculated Venmo fee in approval modal
- Update TransactionService to credit user with actual amount instead of requested amount
- Add Venmo fee warning note in AddFundsModal instructions
- Include fee information in deposit approval notifications
- Validate actual amount cannot exceed requested amount

This ensures accurate cash flow tracking and prevents SideBet from losing money on Venmo transaction fees (typically 1.9% + $0.10 for business accounts).