### PR TITLE
Fix onboarding finish button not responding

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -12,7 +12,6 @@ import {
   Text,
   StyleSheet,
   Modal,
-  Alert,
   Animated,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -21,6 +20,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { getProfilePictureUrl } from '../services/imageUploadService';
+import { showAlert } from '../components/ui/CustomAlert';
 
 // Import step components
 import { OnboardingProfilePictureStep } from '../components/onboarding/OnboardingProfilePictureStep';


### PR DESCRIPTION
The finish button was showing a loader but not completing onboarding. The issue was a missing import for showAlert() which is called when onboarding completes successfully.

Changes:
- Add missing import: showAlert from CustomAlert component
- Remove unused Alert import from react-native

This fix ensures:
- Success alert displays when onboarding completes
- onComplete() callback is triggered properly
- Loading state is cleared after completion
- Follows CLAUDE.md standards (use showAlert instead of Alert.alert)