### PR TITLE
Fix add funds page left alignment issue

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -460,7 +460,6 @@ const styles = StyleSheet.create({
 
   // Payment Methods
   methodsList: {
-    width: '100%',
     marginBottom: spacing.lg,
   },
   methodCard: {
@@ -519,7 +518,6 @@ const styles = StyleSheet.create({
 
   // Input Sections
   inputSection: {
-    width: '100%',
     marginBottom: spacing.lg,
   },
   inputLabel: {
@@ -529,7 +527,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   amountInputContainer: {
-    width: '100%',
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: colors.surface,
@@ -552,7 +549,6 @@ const styles = StyleSheet.create({
     marginLeft: spacing.xs,
   },
   textInput: {
-    width: '100%',
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.border,
@@ -571,7 +567,6 @@ const styles = StyleSheet.create({
 
   // Instructions
   instructionsBox: {
-    width: '100%',
     flexDirection: 'row',
     backgroundColor: colors.info + '20',
     borderRadius: spacing.radius.md,
@@ -598,7 +593,6 @@ const styles = StyleSheet.create({
 
   // Summary
   summaryCard: {
-    width: '100%',
     backgroundColor: colors.surface,
     borderRadius: spacing.radius.lg,
     padding: spacing.lg,
@@ -642,7 +636,6 @@ const styles = StyleSheet.create({
 
   // Warning Banner
   warningBanner: {
-    width: '100%',
     flexDirection: 'row',
     backgroundColor: colors.warning + '20',
     borderRadius: spacing.radius.md,


### PR DESCRIPTION
Remove unnecessary width: '100%' declarations that were causing content to not respect the parent container's left padding. Elements now properly align with the 24px padding from the screen edge.

Fixed elements:
- Payment method list (methodsList)
- Input sections (inputSection, amountInputContainer, textInput)
- Instructions box
- Summary card
- Warning banner