### PR TITLE
Fix transaction history display to show net amounts consistently

### DIFF
--- a/src/screens/BettingHistoryScreen.tsx
+++ b/src/screens/BettingHistoryScreen.tsx
@@ -328,10 +328,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
                      transaction.type === 'BET_CANCELLED' ||
                      transaction.type === 'BET_REFUND';
 
-    // For deposits/withdrawals, use actualAmount if available (after fees)
-    const displayAmount = (transaction.type === 'DEPOSIT' || transaction.type === 'WITHDRAWAL') && transaction.actualAmount !== undefined
-      ? transaction.actualAmount
-      : transaction.amount;
+    let displayAmount = transaction.amount;
+
+    // For transactions with actualAmount, use it (net amount after fees)
+    // This includes: DEPOSIT (after Venmo fees), WITHDRAWAL (after all fees), BET_WON (after platform fee)
+    if (transaction.actualAmount !== undefined) {
+      displayAmount = transaction.actualAmount;
+    }
 
     const sign = isCredit ? '+' : '-';
     return `${sign}${formatCurrency(displayAmount)}`;

--- a/src/screens/ResolveScreen.tsx
+++ b/src/screens/ResolveScreen.tsx
@@ -333,8 +333,9 @@ export const ResolveScreen: React.FC = () => {
                 userId: participant.userId,
                 type: 'BET_WON',
                 status: 'PENDING', // NOT COMPLETED - awaiting dispute window
-                amount: payout, // Gross amount (before fee)
-                platformFee: 0, // Will be set by payout-processor when completed
+                amount: payout, // Gross payout amount (before fees) - consistent with deposits
+                actualAmount: netPayout, // Net amount received after platform fee
+                platformFee: platformFee, // 3% platform fee
                 balanceBefore: currentBalance,
                 balanceAfter: currentBalance + netPayout, // Projected balance (after fee)
                 relatedBetId: bet.id,


### PR DESCRIPTION
BREAKING: Changed BET_WON transaction data model for consistency

Data Model Changes:
- amount: Gross payout (before fees) - e.g., $1.00
- actualAmount: Net payout (after platform fee) - e.g., $0.97
- platformFee: Platform fee charged - e.g., $0.03

This makes BET_WON consistent with DEPOSIT/WITHDRAWAL pattern where:
- amount = gross (requested/won amount)
- actualAmount = net (what user actually receives after fees)

Changes:
1. ResolveScreen.tsx: Store gross in amount, net in actualAmount
2. payout-processor: Credit actualAmount to user balance (not amount)
3. payout-processor: Show platform fee in notification message
4. BettingHistoryScreen: Display actualAmount for all transaction types

Example BET_WON display:
Before: "+$1.00" (confusing - showed gross when user got net) After: "+$0.97" with description "Winnings payout (Platform fee: $0.03)"

This ensures users always see the actual amount they received in their balance.