### PR TITLE
Fix ScrollView padding to prevent text cutoff on left side

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -172,7 +172,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
   };
 
   const renderSelectMethod = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>SELECT VENMO ACCOUNT</Text>
 
       {isLoadingMethods ? (
@@ -246,7 +246,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
   );
 
   const renderEnterDetails = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>DEPOSIT DETAILS</Text>
 
       {/* Amount Input */}
@@ -321,7 +321,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
   );
 
   const renderConfirmation = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>CONFIRM DEPOSIT</Text>
 
       {/* Summary Card */}
@@ -442,6 +442,8 @@ const styles = StyleSheet.create({
   // Content
   stepContent: {
     flex: 1,
+  },
+  stepContentContainer: {
     padding: spacing.lg,
   },
   sectionTitle: {


### PR DESCRIPTION
The issue was that padding was applied to ScrollView's style prop instead of contentContainerStyle. In React Native, padding must be on contentContainerStyle to properly affect the scrollable content.

Split stepContent into:
- stepContent: outer container styling (flex: 1)
- stepContentContainer: content padding (padding: spacing.lg)

This fixes the issue where "DEPOSIT DETAILS" and other text had the first letter partially cut off.