### PR TITLE
Fix pending payouts to show net amounts after platform fees

### DIFF
--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -235,9 +235,13 @@ export const AccountScreen: React.FC = () => {
         }
       });
 
-      // Calculate total pending payouts
+      // Calculate total pending payouts (use actualAmount for net after fees)
       const total = pendingTransactions?.reduce((sum, transaction) => {
-        return sum + (transaction.amount || 0);
+        // Use actualAmount (net after fees) if available, otherwise fall back to amount
+        const netAmount = transaction.actualAmount !== undefined && transaction.actualAmount !== null
+          ? transaction.actualAmount
+          : transaction.amount || 0;
+        return sum + netAmount;
       }, 0) || 0;
 
       setPendingPayouts(total);


### PR DESCRIPTION
- Update AccountScreen to use actualAmount instead of amount for pending payouts
- Shows correct net payout (e.g., $1.94 instead of $2.00 for $2 gross with 3% fee)
- Includes fallback to amount for backward compatibility with old transactions