### PR TITLE
Fix notification display to handle DynamoDB pagination with filters

### DIFF
--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -20,6 +20,7 @@ import { Ionicons } from '@expo/vector-icons';
 // import type { Schema } from '../../amplify/data/resource';
 import { colors, spacing, textStyles, commonStyles, typography } from '../styles';
 import { ModalHeader } from '../components/ui/ModalHeader';
+import { showAlert } from '../components/ui/CustomAlert';
 import { useAuth } from '../contexts/AuthContext';
 import { NotificationService } from '../services/notificationService';
 import { Notification, NotificationType } from '../types/betting';


### PR DESCRIPTION
**Problem:**
- Badge showed 8 unread notifications
- Notification screen only displayed 3 notifications
- DynamoDB applies limit to scan, not to filtered results

**Root Cause:**
When querying with `limit: 20` and `filter: { isRead: false }`:
- DynamoDB scans up to 20 total items (read + unread)
- Then filters for `isRead: false`
- Returns only matching items (could be 0-20)

So if first 20 notifications have only 3 unread, list shows 3 even though total unread count is 8.

**Solution:**
- Implemented proper pagination using nextToken
- Fetches in chunks of 100 until we have requested number of results
- Ensures notification list matches the badge count
- Added detailed logging for debugging

**Files Changed:**
- src/services/notificationService.ts: Added pagination logic to getUserNotifications()
- src/screens/NotificationScreen.tsx: Added missing showAlert import

**Testing:**
- Badge count and list count should now always match
- Pagination will fetch all unread notifications regardless of position