### PR TITLE
Fix friend request notification username display

### DIFF
--- a/src/components/ui/AddFriendModal.tsx
+++ b/src/components/ui/AddFriendModal.tsx
@@ -10,7 +10,6 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   ActivityIndicator,
   FlatList,
   Image,
@@ -28,6 +27,7 @@ import { User } from '../../types/betting';
 import { NotificationService } from '../../services/notificationService';
 import { ModalHeader } from './ModalHeader';
 import { getProfilePictureUrl } from '../../services/imageUploadService';
+import { showAlert } from './CustomAlert';
 
 // Initialize GraphQL client
 const client = generateClient<Schema>();
@@ -195,7 +195,10 @@ export const AddFriendModal: React.FC<AddFriendModalProps> = ({
       if (newRequest) {
         // Fetch current user's display name from database
         const { data: currentUserData } = await client.models.User.get({ id: user.userId });
-        const currentUserDisplayName = currentUserData?.displayName || currentUserData?.username || user.username;
+        // Use displayName first, then extract friendly name from email, finally fallback to "Someone"
+        const currentUserDisplayName = currentUserData?.displayName ||
+          currentUserData?.email?.split('@')[0] ||
+          'Someone';
 
         await NotificationService.notifyFriendRequestReceived(
           targetUser.id,

--- a/src/components/ui/FriendRequestsModal.tsx
+++ b/src/components/ui/FriendRequestsModal.tsx
@@ -9,7 +9,6 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   ActivityIndicator,
   FlatList,
   Image,
@@ -25,6 +24,7 @@ import { User } from '../../types/betting';
 import { NotificationService } from '../../services/notificationService';
 import { ModalHeader } from './ModalHeader';
 import { getProfilePictureUrl } from '../../services/imageUploadService';
+import { showAlert } from './CustomAlert';
 
 // Initialize GraphQL client
 const client = generateClient<Schema>();
@@ -158,7 +158,10 @@ export const FriendRequestsModal: React.FC<FriendRequestsModalProps> = ({
       // Send notification to the original requester
       // Fetch current user's display name from database
       const { data: currentUserData } = await client.models.User.get({ id: user.userId });
-      const currentUserDisplayName = currentUserData?.displayName || currentUserData?.username || user.username;
+      // Use displayName first, then extract friendly name from email, finally fallback to "Someone"
+      const currentUserDisplayName = currentUserData?.displayName ||
+        currentUserData?.email?.split('@')[0] ||
+        'Someone';
 
       await NotificationService.notifyFriendRequestAccepted(
         request.fromUserId,
@@ -198,7 +201,10 @@ export const FriendRequestsModal: React.FC<FriendRequestsModalProps> = ({
         // Fetch current user's display name for the notification
         if (user?.userId) {
           const { data: currentUserData } = await client.models.User.get({ id: user.userId });
-          const currentUserDisplayName = currentUserData?.displayName || currentUserData?.username || 'Someone';
+          // Use displayName first, then extract friendly name from email, finally fallback to "Someone"
+          const currentUserDisplayName = currentUserData?.displayName ||
+            currentUserData?.email?.split('@')[0] ||
+            'Someone';
 
           await NotificationService.createNotification({
             userId: request.fromUserId,


### PR DESCRIPTION
…play name

Changed notification username resolution to prioritize displayName, then extract friendly name from email (before @ symbol), and finally fallback to "Someone". This prevents showing Cognito username hashes/UUIDs in friend request notifications.

Changes:
- AddFriendModal: Updated friend request sent notification to use email-based fallback
- FriendRequestsModal: Updated accept/decline notifications to use email-based fallback
- Added missing showAlert import in both files
- Removed unused Alert import from react-native

The new fallback chain: displayName > email prefix > "Someone" This ensures users always see a human-readable name in notifications.