### PR TITLE
Fix Notification GSI TypeScript error - use single sort key

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -101,11 +101,11 @@ const schema = a.schema({
       relatedBet: a.belongsTo('Bet', 'relatedBetId'),
     })
     .secondaryIndexes((index) => [
-      // Index for efficiently querying unread notifications by user
-      // Allows: SELECT * WHERE userId = X AND isRead = false ORDER BY createdAt DESC
+      // Index for efficiently querying notifications by user ordered by date
+      // Note: isRead filtering happens client-side (acceptable for typical notification counts)
       index('userId')
-        .sortKeys(['isRead', 'createdAt'])
-        .queryField('notificationsByUserAndReadStatus')
+        .sortKeys(['createdAt'])
+        .queryField('notificationsByUser')
     ])
     .authorization((allow) => [
       allow.authenticated().to(['read', 'create', 'update']) // Any authenticated user can create/read/update notifications


### PR DESCRIPTION
**Problem:**
TypeScript error: sortKeys(['isRead', 'createdAt']) is invalid DynamoDB GSIs only support ONE sort key, not multiple fields

**Solution:**
Changed Notification GSI to use createdAt as the only sort key:
- Partition key: userId
- Sort key: createdAt (single field)
- Query field: notificationsByUser

**Trade-off:**
- isRead filtering now happens client-side after GSI query
- Fetches 2x requested limit to account for filtering
- Still much more efficient than original scan+filter approach
- Acceptable for typical notification volumes (<100 per user)

**Changes:**
1. amplify/data/resource.ts:
   - Changed .sortKeys(['isRead', 'createdAt']) to .sortKeys(['createdAt'])
   - Renamed query field to notificationsByUser
   - Added comment explaining client-side isRead filtering

2. src/services/notificationService.ts:
   - Updated to use notificationsByUser GSI query
   - Added client-side isRead filter (fetches limit*2 to compensate)
   - Both unread and all notifications now use efficient GSI
   - Removed redundant client-side sorting (GSI returns sorted)

**Performance:**
- Before fix: Compilation error, can't deploy
- After fix: Compiles successfully, efficient date-ordered queries
- isRead filter: O(n) client-side, but n is small (<100 typically)