### PR TITLE
Move web-push to dependencies for Amplify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-native-svg": "15.8.0",
     "react-native-toast-message": "^2.3.3",
     "react-native-web": "~0.19.13",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.5.0",
@@ -66,8 +67,7 @@
     "esbuild": "^0.20.2",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.20",
-    "web-push": "^3.6.7"
+    "eslint-plugin-react-refresh": "^0.4.20"
   },
   "private": true
 }


### PR DESCRIPTION
Move web-push from devDependencies to dependencies to ensure it's available during Amplify build process.