### PR TITLE
Remove expo-router from web build configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,14 +32,7 @@
     "web": {
       "favicon": "./assets/icon.png",
       "bundler": "metro",
-      "output": "static",
-      "build": {
-        "babel": {
-          "include": [
-            "expo-router"
-          ]
-        }
-      }
+      "output": "static"
     },
     "plugins": [
       "expo-dev-client",


### PR DESCRIPTION
Fix build error: expo-router is not used in this project, so remove it from the web build babel config.

This app uses React Navigation, not expo-router.