### PR TITLE
Remove metro bundler config from web build

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,9 +30,7 @@
       "versionCode": 1
     },
     "web": {
-      "favicon": "./assets/icon.png",
-      "bundler": "metro",
-      "output": "static"
+      "favicon": "./assets/icon.png"
     },
     "plugins": [
       "expo-dev-client",


### PR DESCRIPTION
Metro bundler for web requires expo-router which this app doesn't use. Use Expo's default webpack bundler for web instead.

This app uses React Navigation, not expo-router, so metro's SSR features aren't needed.