### PR TITLE
Register service worker on app startup for web platform

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,9 +15,9 @@ import amplifyconfig from './amplify_outputs.json';
 Amplify.configure(amplifyconfig);
 
 // Now import components that use Amplify
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View, ActivityIndicator } from 'react-native';
+import { StyleSheet, View, ActivityIndicator, Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
 import { EventCheckInProvider } from './src/contexts/EventCheckInContext';
@@ -28,6 +28,7 @@ import { colors } from './src/styles';
 import Toast from 'react-native-toast-message';
 import { toastConfig } from './src/components/ui/ToastConfig';
 import { CustomAlertController } from './src/components/ui/CustomAlert';
+import { registerServiceWorker } from './src/utils/webPushUtils';
 
 type AuthScreen = 'login' | 'signup';
 
@@ -75,6 +76,20 @@ function MainApp() {
 }
 
 export default function App() {
+  // Register service worker on app startup (web only)
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      console.log('[App] Registering service worker on startup...');
+      registerServiceWorker()
+        .then(() => {
+          console.log('[App] ✅ Service worker registered successfully on startup');
+        })
+        .catch((error) => {
+          console.error('[App] ❌ Service worker registration failed:', error);
+        });
+    }
+  }, []);
+
   return (
     <SafeAreaProvider>
       <AuthProvider>


### PR DESCRIPTION
Key changes to match working SweatSync implementation:

1. App.tsx - Register service worker on startup (web only)
   - Mimics vite-plugin-pwa auto-registration behavior
   - Ensures service worker is ready before push subscription attempts

2. webPushUtils.ts - Use navigator.serviceWorker.ready
   - No longer calls registerServiceWorker() during subscription
   - Waits for already-registered worker (registered in App.tsx)
   - Added detailed console logging for debugging

This matches the pattern from the working SweatSync app where the service worker is registered once on startup, then permission requests just use the ready worker.

Fixes the issue where notification permission prompt wasn't appearing because service worker wasn't registered early enough.