### PR TITLE
Check event query period-based score access

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -499,6 +499,8 @@ const schema = a.schema({
       // Scores
       homeScore: a.integer().default(0),
       awayScore: a.integer().default(0),
+      homePeriodScores: a.json(), // Array of period scores [Q1, Q2, Q3, Q4, ...OT] - index is period number
+      awayPeriodScores: a.json(), // Array of period scores [Q1, Q2, Q3, Q4, ...OT] - index is period number
       // Game state
       status: a.enum(['UPCOMING', 'LIVE', 'HALFTIME', 'FINISHED', 'POSTPONED', 'CANCELLED']),
       quarter: a.string(), // e.g., "Q1", "Q2", "Halftime", "OT"

--- a/amplify/functions/event-fetcher/handler.ts
+++ b/amplify/functions/event-fetcher/handler.ts
@@ -23,11 +23,16 @@ interface ESPNTeam {
   displayName: string;
 }
 
+interface ESPNLinescore {
+  value: number;
+}
+
 interface ESPNCompetitor {
   id: string;
   homeAway: 'home' | 'away';
   team: ESPNTeam;
   score: string;
+  linescores?: ESPNLinescore[];
   winner?: boolean;
 }
 
@@ -267,6 +272,8 @@ async function upsertEvent(event: ESPNEvent, league: string): Promise<void> {
       country: undefined, // ESPN doesn't provide country in this endpoint
       homeScore: parseInt(homeCompetitor.score) || 0,
       awayScore: parseInt(awayCompetitor.score) || 0,
+      homePeriodScores: homeCompetitor.linescores?.map(ls => ls.value) || undefined,
+      awayPeriodScores: awayCompetitor.linescores?.map(ls => ls.value) || undefined,
       status: status,
       isActive: isActive, // Lifecycle state managed by Lambda for efficient querying (1=active, 0=inactive)
       quarter: competition.status.period ? `Period ${competition.status.period}` : undefined,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -24,6 +24,8 @@ export interface LiveEvent {
   country?: string;
   homeScore: number;
   awayScore: number;
+  homePeriodScores?: number[]; // Array of period scores [Q1, Q2, Q3, Q4, ...OT] - index is period number
+  awayPeriodScores?: number[]; // Array of period scores [Q1, Q2, Q3, Q4, ...OT] - index is period number
   status: EventStatus;
   quarter?: string; // e.g., "Q1", "Q2", "Halftime"
   timeLeft?: string; // e.g., "8:42"


### PR DESCRIPTION
- Add homePeriodScores and awayPeriodScores JSON fields to LiveEvent model
- Extract linescores array from ESPN API competitors (maps to quarter/period scores)
- Store period scores as number arrays where index = period number (0=Q1, 1=Q2, etc.)
- Update TypeScript interfaces in event-fetcher handler and frontend types
- Period scores automatically populated by event-fetcher Lambda every 15 minutes

Enables future features:
- Quarter-by-quarter score display in UI
- Period-specific betting (e.g., "Who wins Q3?")
- Scoring momentum analysis