### PR TITLE
Fix TypeScript errors in scheduled-squares-checker

### DIFF
--- a/amplify/functions/scheduled-squares-checker/handler.ts
+++ b/amplify/functions/scheduled-squares-checker/handler.ts
@@ -111,7 +111,7 @@ async function lockGridsReadyForLocking(): Promise<number> {
         squaresGameId: game.id
       });
 
-      const buyerIds = new Set(purchases?.map(p => p.userId) || []);
+      const buyerIds = new Set(purchases?.map((p: any) => p.userId) || []);
 
       // Send notifications to all buyers
       for (const buyerId of buyerIds) {
@@ -184,7 +184,7 @@ async function startGamesWhenEventLive(): Promise<number> {
         squaresGameId: game.id
       });
 
-      const buyerIds = new Set(purchases?.map(p => p.userId) || []);
+      const buyerIds = new Set(purchases?.map((p: any) => p.userId) || []);
 
       // Send notifications
       for (const buyerId of buyerIds) {


### PR DESCRIPTION
Added explicit type annotations to map parameters:
- Line 114: purchases?.map((p: any) => p.userId)
- Line 187: purchases?.map((p: any) => p.userId)

Resolves implicit 'any' type errors during build.