### PR TITLE
Fix remaining TypeScript error in scheduled-squares-checker

### DIFF
--- a/amplify/functions/scheduled-squares-checker/handler.ts
+++ b/amplify/functions/scheduled-squares-checker/handler.ts
@@ -254,7 +254,7 @@ async function processPeriodScoresForLiveGames(): Promise<number> {
         squaresGameId: game.id
       });
 
-      const paidPeriods = new Set(existingPayouts?.map(p => p.period) || []);
+      const paidPeriods = new Set(existingPayouts?.map((p: any) => p.period) || []);
 
       // Process each period (1-4)
       for (let period = 1; period <= 4; period++) {


### PR DESCRIPTION
Added explicit type annotation to map parameter:
- Line 257: existingPayouts?.map((p: any) => p.period)

Resolves final implicit 'any' type error during build.