### PR TITLE
Fix schema relationship: Add squaresGames hasMany to LiveEvent

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -532,7 +532,8 @@ const schema = a.schema({
       createdAt: a.datetime(),
       updatedAt: a.datetime(),
       // Relations
-      checkIns: a.hasMany('EventCheckIn', 'eventId')
+      checkIns: a.hasMany('EventCheckIn', 'eventId'),
+      squaresGames: a.hasMany('SquaresGame', 'eventId')
     })
     .secondaryIndexes((index) => [
       index('status').sortKeys(['scheduledTime']).queryField('listEventsByStatusAndTime'),


### PR DESCRIPTION
Fixed InvalidSchemaError by adding missing relationship:
- LiveEvent now has: squaresGames: a.hasMany('SquaresGame', 'eventId')
- This completes the bidirectional relationship with SquaresGame.event belongsTo

Resolves: Unable to find associated relationship definition in LiveEvent for SquaresGame.event