### PR TITLE
Fix schema relationship: Add payouts hasMany to SquaresPurchase

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -624,6 +624,7 @@ const schema = a.schema({
       // Relations
       buyer: a.belongsTo('User', 'userId'),
       squaresGame: a.belongsTo('SquaresGame', 'squaresGameId'),
+      payouts: a.hasMany('SquaresPayout', 'squaresPurchaseId'),
     })
     .secondaryIndexes((index) => [
       index('squaresGameId').sortKeys(['purchasedAt']).queryField('purchasesBySquaresGame'),


### PR DESCRIPTION
Fixed InvalidSchemaError by adding missing relationship:
- SquaresPurchase now has: payouts: a.hasMany('SquaresPayout', 'squaresPurchaseId')
- This completes the bidirectional relationship with SquaresPayout.squaresPurchase belongsTo

Resolves: Unable to find associated relationship definition in SquaresPurchase for SquaresPayout.squaresPurchase