### PR TITLE
Fix payoutStructure JSON serialization for GraphQL

### DIFF
--- a/src/services/squaresGameService.ts
+++ b/src/services/squaresGameService.ts
@@ -79,7 +79,7 @@ export class SquaresGameService {
         description,
         pricePerSquare,
         totalPot: 0,
-        payoutStructure: payoutStructure as any,
+        payoutStructure: JSON.stringify(payoutStructure), // Schema expects JSON string
         status: 'ACTIVE',
         squaresSold: 0,
         numbersAssigned: false,


### PR DESCRIPTION
- Change payoutStructure from object to JSON.stringify()
- Schema expects json() type which requires string format
- Resolves GraphQL validation error on game creation