### PR TITLE
Wire up squares game detail navigation

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -23,6 +23,7 @@ import { CreateBetScreen } from '../screens/CreateBetScreen';
 import { ResolveScreen } from '../screens/ResolveScreen';
 import { AccountScreen } from '../screens/AccountScreen';
 import { OnboardingScreen } from '../screens/OnboardingScreen';
+import { SquaresGameDetailScreen } from '../screens/SquaresGameDetailScreen';
 
 // Create navigators
 const Tab = createBottomTabNavigator<AppTabParamList>();
@@ -47,6 +48,11 @@ const BetsStackNavigator = () => {
         name="BetsList"
         component={BetsScreen}
         options={{ headerShown: false }} // We'll use custom header
+      />
+      <BetsStack.Screen
+        name="SquaresGameDetail"
+        component={SquaresGameDetailScreen}
+        options={{ headerShown: false }} // SquaresGameDetailScreen has custom header
       />
     </BetsStack.Navigator>
   );

--- a/src/screens/BetsScreen.tsx
+++ b/src/screens/BetsScreen.tsx
@@ -17,17 +17,22 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
 import { commonStyles, colors, spacing, typography, textStyles } from '../styles';
 import { Header } from '../components/ui/Header';
 import { BetCard } from '../components/betting/BetCard';
 import { SquaresGameCard } from '../components/betting/SquaresGameCard';
 import { BetInviteModal } from '../components/ui/BetInviteModal';
 import { Bet, BetInvitation, BetInvitationStatus, User, ParticipantStatus } from '../types/betting';
+import { BetsStackParamList } from '../types/navigation';
 import { useAuth } from '../contexts/AuthContext';
 import { NotificationService } from '../services/notificationService';
 import { TransactionService } from '../services/transactionService';
 import { bulkLoadUserBetsWithParticipants, clearBulkLoadingCache } from '../services/bulkLoadingService';
 import { showAlert } from '../components/ui/CustomAlert';
+
+type BetsScreenNavigationProp = StackNavigationProp<BetsStackParamList, 'BetsList'>;
 
 // Initialize GraphQL client
 const client = generateClient<Schema>();
@@ -89,6 +94,7 @@ interface SquaresGame {
 
 export const BetsScreen: React.FC = () => {
   const { user } = useAuth();
+  const navigation = useNavigation<BetsScreenNavigationProp>();
   const insets = useSafeAreaInsets();
   const [bets, setBets] = useState<Bet[]>([]);
   const [squaresGames, setSquaresGames] = useState<SquaresGame[]>([]);
@@ -582,8 +588,8 @@ export const BetsScreen: React.FC = () => {
   };
 
   const handleSquaresGamePress = (gameId: string) => {
-    // TODO: Navigate to SquaresGameDetailScreen
-    console.log('Navigate to squares game:', gameId);
+    console.log('[BetsScreen] Navigating to squares game:', gameId);
+    navigation.navigate('SquaresGameDetail', { gameId });
   };
 
   // Set up real-time subscriptions with debouncing

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -42,6 +42,9 @@ export type BetsStackParamList = {
   UserProfile: {
     userId: string;
   };
+  SquaresGameDetail: {
+    gameId: string;
+  };
 };
 
 // Live Stack Navigator (live betting screens)
@@ -140,6 +143,7 @@ export const SCREENS = {
   BET_DETAILS: 'BetDetails' as const,
   JOIN_BET: 'JoinBet' as const,
   USER_PROFILE: 'UserProfile' as const,
+  SQUARES_GAME_DETAIL: 'SquaresGameDetail' as const,
   
   // Live
   LIVE_EVENTS: 'LiveEvents' as const,


### PR DESCRIPTION
- Add SquaresGameDetail screen to BetsStackParamList
- Add SQUARES_GAME_DETAIL constant to SCREENS
- Import and register SquaresGameDetailScreen in AppNavigator
- Add SquaresGameDetail screen to BetsStack navigator
- Implement navigation in BetsScreen handleSquaresGamePress
- Users can now tap squares game cards to view full details