### PR TITLE
Add formatDateTime function and fix payoutStructure parsing

### DIFF
--- a/src/screens/SquaresGameDetailScreen.tsx
+++ b/src/screens/SquaresGameDetailScreen.tsx
@@ -240,7 +240,11 @@ export const SquaresGameDetailScreen = ({ route, navigation }: any) => {
         {/* Payout Structure */}
         <View style={styles.payoutCard}>
           <Text style={styles.cardTitle}>Prize Breakdown</Text>
-          {Object.entries(game.payoutStructure).map(([period, percentage]: [string, any]) => {
+          {Object.entries(
+            typeof game.payoutStructure === 'string'
+              ? JSON.parse(game.payoutStructure)
+              : game.payoutStructure
+          ).map(([period, percentage]: [string, any]) => {
             const periodNum = parseInt(period.replace('period', ''));
             const amount = game.totalPot * percentage;
             const netAmount = amount * 0.97; // After 3% fee

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -44,6 +44,44 @@ export const formatPercentage = (
 };
 
 // Date and time formatting
+export const formatDateTime = (
+  date: string | Date,
+  format: 'full' | 'short' | 'date' | 'time' = 'full'
+): string => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+
+  switch (format) {
+    case 'short':
+      return d.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    case 'date':
+      return d.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    case 'time':
+      return d.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    case 'full':
+    default:
+      return d.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+  }
+};
+
 export const dateFormatting = {
   // Format date for betting deadlines
   formatDeadline: (date: string | Date): string => {


### PR DESCRIPTION
Critical fixes for squares game detail screen:
- Add formatDateTime function to formatting utility
  - Supports 'full', 'short', 'date', 'time' formats
  - Used by SquaresGameDetailScreen and SquaresGameCard
- Fix payoutStructure JSON parsing in SquaresGameDetailScreen
  - Schema stores as JSON string, needs parsing before Object.entries
  - Added typeof check to handle both string and object formats
- Resolves "formatDateTime is not a function" error
- Resolves payoutStructure display issues