### PR TITLE
Fix squares detail UI: responsive grid, clear labels, cancel stuck games

### DIFF
--- a/src/screens/SquaresGameDetailScreen.tsx
+++ b/src/screens/SquaresGameDetailScreen.tsx
@@ -138,6 +138,31 @@ export const SquaresGameDetailScreen = ({ route, navigation }: any) => {
     }
   };
 
+  const handleCancelGame = () => {
+    showAlert(
+      'Cancel Game?',
+      'This will cancel the game and refund all participants. This action cannot be undone.',
+      [
+        { text: 'Keep Game', style: 'cancel' },
+        {
+          text: 'Cancel Game',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const reason = 'Game cancelled by creator';
+              await SquaresGameService.cancelSquaresGame(game.id, reason);
+              showAlert('Game Cancelled', 'The game has been cancelled and all participants have been refunded.');
+              navigation.goBack();
+            } catch (error) {
+              console.error('Error cancelling game:', error);
+              showAlert('Error', 'Failed to cancel game. Please try again.');
+            }
+          },
+        },
+      ]
+    );
+  };
+
   const myPurchases = purchases.filter((p) => p.userId === user?.userId);
 
   // Group purchases by owner name
@@ -405,6 +430,20 @@ export const SquaresGameDetailScreen = ({ route, navigation }: any) => {
                 : 'Select Squares to Purchase'}
             </Text>
           </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Creator Cancel Button */}
+      {user && game.creatorId === user.userId && game.status !== 'RESOLVED' && game.status !== 'CANCELLED' && (
+        <View style={styles.creatorActions}>
+          <TouchableOpacity style={styles.cancelButton} onPress={handleCancelGame}>
+            <Text style={styles.cancelButtonText}>Cancel Game & Refund All</Text>
+          </TouchableOpacity>
+          <Text style={styles.cancelHint}>
+            {purchases.length > 0
+              ? `This will refund ${purchases.length} purchase${purchases.length > 1 ? 's' : ''}`
+              : 'Cancel this game if it cannot proceed'}
+          </Text>
         </View>
       )}
 
@@ -712,5 +751,28 @@ const styles = StyleSheet.create({
     ...textStyles.button,
     color: colors.textInverse,
     fontWeight: typography.fontWeight.bold,
+  },
+  creatorActions: {
+    padding: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  cancelButton: {
+    backgroundColor: colors.error,
+    paddingVertical: spacing.sm,
+    borderRadius: spacing.radius.sm,
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  cancelButtonText: {
+    ...textStyles.body,
+    color: colors.textInverse,
+    fontWeight: typography.fontWeight.semibold,
+  },
+  cancelHint: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
Addresses 3 critical UX issues with the squares game detail screen:

1. RESPONSIVE GRID SIZING:
   - Calculate cell size dynamically based on screen width
   - Grid now fits perfectly on mobile/web without cutoff
   - Add horizontal ScrollView as fallback for small screens
   - Scale font sizes proportionally with cell size
   - Formula: CELL_SIZE = (screenWidth - padding - headers) / 10

2. CLEAR TEAM AXIS LABELS:
   - Add prominent axis labels above grid: "↓ Home (Rows)" and "→ Away (Columns)"
   - Remove confusing corner cell team label
   - Users now understand which axis corresponds to which team
   - Labels only show after numbers assigned (when grid is locked)

3. CANCEL STUCK GAMES:
   - Add "Cancel Game & Refund All" button for creators
   - Visible for any non-RESOLVED, non-CANCELLED game
   - Confirmation dialog with destructive action warning
   - Uses existing SquaresGameService.cancelSquaresGame()
   - Refunds all purchases and sends notifications
   - Returns to previous screen after cancellation
   - Helpful hint showing purchase count to refund

Files modified:
- src/components/betting/SquaresGrid.tsx: Responsive sizing, scrollview, axis labels
- src/screens/SquaresGameDetailScreen.tsx: Cancel button with handler and styles

Result: Grid fits all screens, team axes are clear, creators can clean up stuck games from old events that never resolved properly.