### PR TITLE
Fix critical bugs in squares invitation and navigation

### DIFF
--- a/src/components/betting/CreateSquaresForm.tsx
+++ b/src/components/betting/CreateSquaresForm.tsx
@@ -230,6 +230,7 @@ export const CreateSquaresForm: React.FC<CreateSquaresFormProps> = ({
         description: description.trim() || undefined,
         pricePerSquare: price,
         payoutStructure,
+        isPrivate: selectedFriends.size > 0, // Set private if friends are invited
       });
 
       if (gameId) {

--- a/src/screens/BetsScreen.tsx
+++ b/src/screens/BetsScreen.tsx
@@ -311,7 +311,7 @@ export const BetsScreen: React.FC = () => {
         ...additionalGames.map(g => g.data).filter(Boolean)
       ];
 
-      // Transform and filter for ACTIVE, LOCKED, or LIVE games
+      // Transform and filter for ACTIVE, LOCKED, or LIVE games only
       const transformedGames: SquaresGame[] = allGames
         .filter(game =>
           game &&

--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -484,7 +484,7 @@ export const LiveEventsScreen: React.FC = () => {
 
   const handleSquaresGamePress = (game: SquaresGame) => {
     console.log('Squares game pressed:', game.title);
-    navigation.navigate('SquaresGameDetail', { squaresGameId: game.id });
+    navigation.navigate('SquaresGameDetail', { gameId: game.id });
   };
 
   const handleJoinBet = (betId: string, side: string, amount: number) => {


### PR DESCRIPTION
Fixed three major issues reported by user testing:

1. **Private Games Not Created Properly** (CRITICAL FIX)
   - CreateSquaresForm wasn't setting isPrivate flag
   - Now sets isPrivate: true when friends are selected
   - This was preventing invited friends from seeing private games

2. **Squares Games Not Clickable** (NAVIGATION FIX)
   - LiveEventsScreen was passing squaresGameId parameter
   - SquaresGameDetailScreen expects gameId parameter
   - Fixed parameter mismatch - games now clickable

3. **Ended Games Showing on Active Page** (NOT A BUG)
   - BetsScreen filter logic is already correct
   - Only shows ACTIVE, LOCKED, or LIVE status
   - Issue is likely Lambda not updating status to RESOLVED
   - This needs backend investigation (scheduledSquaresChecker)

Files modified:
- src/components/betting/CreateSquaresForm.tsx
- src/screens/LiveEventsScreen.tsx
- src/screens/BetsScreen.tsx (comment update only)