### PR TITLE
Improve transaction descriptions and reduce resolution timeout

### DIFF
--- a/amplify/functions/scheduled-squares-checker/handler.ts
+++ b/amplify/functions/scheduled-squares-checker/handler.ts
@@ -487,9 +487,9 @@ async function resolveCompletedGames(): Promise<number> {
         continue;
       }
 
-      // FALLBACK: If game has been LIVE for more than 7 days, force resolution
+      // FALLBACK: If game has been LIVE for more than 2 days, force resolution
       const daysSinceLocked = (now.getTime() - new Date(game.locksAt).getTime()) / (1000 * 60 * 60 * 24);
-      const isOldGame = daysSinceLocked > 7;
+      const isOldGame = daysSinceLocked > 2;
 
       // Check if event is FINISHED or game is old
       const isEventFinished = event.status === 'FINISHED';

--- a/src/services/squaresGameService.ts
+++ b/src/services/squaresGameService.ts
@@ -182,11 +182,23 @@ export class SquaresGameService {
       }
 
       // Deduct from buyer's balance
+      // Build square positions string: "3 squares (A3, B5, C7)"
+      const squareCount = purchases.length;
+      const squarePositionsString = squareCount <= 3
+        ? purchases.map(p => {
+            const rowLabel = String.fromCharCode(65 + p.gridRow); // A-J
+            const colLabel = p.gridCol + 1; // 1-10
+            return `${rowLabel}${colLabel}`;
+          }).join(', ')
+        : `${squareCount} squares`;
+
       const transaction = await TransactionService.recordSquaresPurchase(
         userId,
         totalCost,
         squaresGameId,
-        purchases.map((p) => p.id).join(',')
+        purchases.map((p) => p.id).join(','),
+        game.title,
+        squarePositionsString
       );
 
       // Update transaction IDs on purchases

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -789,15 +789,28 @@ export class TransactionService {
     userId: string,
     amount: number,
     squaresGameId: string,
-    purchaseIds: string
+    purchaseIds: string,
+    gameTitle?: string,
+    squarePositions?: string
   ): Promise<Transaction | null> {
+    // Build descriptive notes
+    let notes = 'Squares purchase';
+    if (gameTitle) {
+      notes = `${gameTitle}`;
+      if (squarePositions) {
+        notes += ` - ${squarePositions}`;
+      }
+    } else if (purchaseIds) {
+      notes += `: ${purchaseIds}`;
+    }
+
     return await this.createTransaction({
       userId,
       type: 'SQUARES_PURCHASE',
       amount,
       status: 'COMPLETED',
       relatedSquaresGameId: squaresGameId,
-      notes: `Purchased squares: ${purchaseIds}`,
+      notes,
     });
   }
 


### PR DESCRIPTION
**Issue 2 Fixed: Better Transaction Descriptions**
- Changed from hash IDs to readable descriptions
- Format: "Game Title - A3, B5, C7" (for 1-3 squares)
- Format: "Game Title - 5 squares" (for 4+ squares)
- Example: "Steelers @ Browns Squares - A3, B5"

Changes:
- TransactionService.recordSquaresPurchase() now accepts gameTitle and squarePositions
- SquaresGameService builds square position string (A1-J10 format)
- Falls back to purchase IDs if title missing

**Issue 4 Fixed: Reduce Resolution Timeout**
- Changed from 7-day to 2-day fallback
- Games from 2 days ago will now resolve/mark PENDING_RESOLUTION
- Helps clear stuck games faster

Files modified:
- src/services/transactionService.ts
- src/services/squaresGameService.ts
- amplify/functions/scheduled-squares-checker/handler.ts