### PR TITLE
Debug lambda function for live events

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -547,7 +547,7 @@ const schema = a.schema({
     ])
     .authorization((allow) => [
       // The eventFetcher Lambda needs full CRUD access to manage live events
-      allow.handler(eventFetcher).to(['create', 'read', 'update', 'delete']),
+      allow.resource(eventFetcher).to(['create', 'read', 'update', 'delete']),
       // All authenticated users should be able to read event data for display
       allow.authenticated().to(['read']),
     ]),

--- a/amplify/functions/event-fetcher/handler.ts
+++ b/amplify/functions/event-fetcher/handler.ts
@@ -273,8 +273,8 @@ async function upsertEvent(event: ESPNEvent, league: string): Promise<void> {
       country: undefined, // ESPN doesn't provide country in this endpoint
       homeScore: parseInt(homeCompetitor.score) || 0,
       awayScore: parseInt(awayCompetitor.score) || 0,
-      homePeriodScores: homeCompetitor.linescores ? JSON.stringify(homeCompetitor.linescores.map(ls => ls.value)) : undefined,
-      awayPeriodScores: awayCompetitor.linescores ? JSON.stringify(awayCompetitor.linescores.map(ls => ls.value)) : undefined,
+      homePeriodScores: homeCompetitor.linescores?.map(ls => ls.value) || undefined,
+      awayPeriodScores: awayCompetitor.linescores?.map(ls => ls.value) || undefined,
       status: status,
       isActive: isActive, // Lifecycle state managed by Lambda for efficient querying (1=active, 0=inactive)
       quarter: competition.status.period ? `Period ${competition.status.period}` : undefined,
@@ -298,10 +298,8 @@ async function upsertEvent(event: ESPNEvent, league: string): Promise<void> {
         } else {
           console.log(`✅ Updated: ${awayCompetitor.team.abbreviation} @ ${homeCompetitor.team.abbreviation} (id: ${existingEvent.id}, status: ${status}, scores: ${eventData.awayScore}-${eventData.homeScore})`);
           // Log period scores if available
-          const homeScores = eventData.homePeriodScores ? JSON.parse(eventData.homePeriodScores) : [];
-          const awayScores = eventData.awayPeriodScores ? JSON.parse(eventData.awayPeriodScores) : [];
-          if (homeScores.length > 0 || awayScores.length > 0) {
-            console.log(`   📊 Period scores - Away: [${awayScores.join(', ')}], Home: [${homeScores.join(', ')}]`);
+          if (eventData.homePeriodScores && eventData.awayPeriodScores) {
+            console.log(`   📊 Period scores - Away: [${eventData.awayPeriodScores.join(', ')}], Home: [${eventData.homePeriodScores.join(', ')}]`);
           }
         }
       } catch (updateError) {


### PR DESCRIPTION
Two critical fixes to enable live event updates:

1. Fix LiveEvent authorization (amplify/data/resource.ts)
   - Changed allow.handler() to allow.resource() on line 550
   - allow.handler() is invalid syntax and was blocking ALL database writes
   - This prevented homeScore, awayScore, status, and period scores from updating

2. Remove JSON.stringify from period scores (amplify/functions/event-fetcher/handler.ts)
   - Removed JSON.stringify() from homePeriodScores and awayPeriodScores
   - Amplify's a.json() schema type automatically handles serialization
   - Double-stringifying caused data corruption
   - Also fixed logging code to match (removed JSON.parse)

These changes restore the Lambda's ability to write live score updates to the database.