### PR TITLE
Add deep linking for squares bets and regular bets from notifications and transaction history

### DIFF
--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
 import { colors, typography, spacing, textStyles, shadows } from '../../styles';
 import { UserBalance } from './UserBalance';
 import { LiveGameBanner } from './LiveGameBanner';
@@ -42,6 +43,7 @@ export const Header: React.FC<HeaderProps> = ({
   notificationCount, // Remove default value, we'll fetch it
 }) => {
   const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
   const { user } = useAuth();
   const { unreadCount, refreshUnreadCount } = useNotifications();
   const [showNotificationModal, setShowNotificationModal] = useState(false);
@@ -146,6 +148,7 @@ export const Header: React.FC<HeaderProps> = ({
           // Refresh notification count when modal closes
           refreshUnreadCount();
         }}
+        navigation={navigation}
       />
 
       {/* Event Discovery Modal */}

--- a/src/components/ui/NotificationModal.tsx
+++ b/src/components/ui/NotificationModal.tsx
@@ -11,11 +11,13 @@ import { colors } from '../../styles';
 interface NotificationModalProps {
   visible: boolean;
   onClose: () => void;
+  navigation?: any; // Navigation prop for deep linking
 }
 
 export const NotificationModal: React.FC<NotificationModalProps> = ({
   visible,
   onClose,
+  navigation,
 }) => {
   return (
     <Modal
@@ -28,7 +30,7 @@ export const NotificationModal: React.FC<NotificationModalProps> = ({
         barStyle="light-content"
         backgroundColor={colors.surface}
       />
-      <NotificationScreen onClose={onClose} />
+      <NotificationScreen onClose={onClose} navigation={navigation} />
     </Modal>
   );
 };

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import { generateClient } from 'aws-amplify/data';
 import { fetchUserAttributes } from 'aws-amplify/auth';
 import type { Schema } from '../../amplify/data/resource';
@@ -53,6 +54,7 @@ interface UserProfile extends User {
 export const AccountScreen: React.FC = () => {
   const { user, signOut } = useAuth();
   const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -664,7 +666,10 @@ export const AccountScreen: React.FC = () => {
         presentationStyle="fullScreen"
         onRequestClose={() => setShowBettingHistory(false)}
       >
-        <BettingHistoryScreen onClose={() => setShowBettingHistory(false)} />
+        <BettingHistoryScreen
+          onClose={() => setShowBettingHistory(false)}
+          navigation={navigation}
+        />
       </Modal>
 
       {/* Payment Methods Modal */}


### PR DESCRIPTION
Changes:
- BettingHistoryScreen: Make transaction cards clickable when they have related bet/squares game
  - Added navigation prop to enable deep linking
  - Added handleTransactionPress to navigate to bet details or squares game detail
  - Added chevron icon to clickable transaction cards for visual feedback
  - Wrapped clickable cards in TouchableOpacity

- NotificationScreen: Implement actual navigation instead of console logs
  - Import and use getNotificationNavigationAction utility
  - Navigate to SquaresGameDetail for squares notifications
  - Navigate to BetDetails for bet notifications
  - Close modal before navigating for better UX

- AccountScreen: Pass navigation to BettingHistoryScreen
  - Import and use useNavigation hook
  - Pass navigation prop to BettingHistoryScreen modal

- Header: Pass navigation to NotificationModal
  - Import and use useNavigation hook
  - Pass navigation prop to NotificationModal

- NotificationModal: Accept and forward navigation prop to NotificationScreen

Navigation flow:
- Transaction tap → Close modal → Navigate to Bets tab → Open detail screen
- Notification tap → Mark as read → Close modal → Navigate to appropriate screen