### PR TITLE
Fix navigation timing for squares bet deep linking

### DIFF
--- a/src/screens/BettingHistoryScreen.tsx
+++ b/src/screens/BettingHistoryScreen.tsx
@@ -44,23 +44,25 @@ export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onCl
 
     // Navigate to squares game detail if it's a squares transaction
     if (transaction.relatedSquaresGameId) {
-      onClose(); // Close the modal first
-      // Navigate to Bets tab, then to SquaresGameDetail
+      // Navigate first, then close modal with delay to ensure navigation completes
       navigation.navigate('Bets', {
         screen: 'SquaresGameDetail',
         params: { gameId: transaction.relatedSquaresGameId }
       });
+      // Close modal after a brief delay to let navigation start
+      setTimeout(() => onClose(), 100);
       return;
     }
 
     // Navigate to bet details if it's a bet transaction
     if (transaction.relatedBetId) {
-      onClose(); // Close the modal first
-      // Navigate to Bets tab, then to BetDetails
+      // Navigate first, then close modal with delay to ensure navigation completes
       navigation.navigate('Bets', {
         screen: 'BetDetails',
         params: { betId: transaction.relatedBetId }
       });
+      // Close modal after a brief delay to let navigation start
+      setTimeout(() => onClose(), 100);
       return;
     }
   };

--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -241,12 +241,7 @@ export const NotificationScreen: React.FC<NotificationScreenProps> = ({ onClose,
       return;
     }
 
-    // Close modal before navigating
-    if (onClose) {
-      onClose();
-    }
-
-    // Handle navigation based on action type
+    // Handle navigation based on action type (navigate BEFORE closing modal)
     if (navigationAction.action === 'navigate') {
       const { screen, params } = navigationAction;
 
@@ -296,6 +291,11 @@ export const NotificationScreen: React.FC<NotificationScreenProps> = ({ onClose,
       } else {
         console.log('[NotificationScreen] Unknown modal:', modal);
       }
+    }
+
+    // Close modal after navigation starts (with small delay to ensure navigation completes)
+    if (onClose) {
+      setTimeout(() => onClose(), 100);
     }
   }, [navigation, onClose]);
 


### PR DESCRIPTION
Issue: Navigation to SquaresGameDetail was failing because modal was closing before the nested navigation could complete.

Solution: Reversed the order - navigate first, then close modal with a 100ms delay to ensure navigation starts before the modal unmounts.

Changes:
- BettingHistoryScreen: Navigate first, then close modal after delay
- NotificationScreen: Navigate first, then close modal after delay

This ensures the navigation.navigate() call completes before the modal context is removed, allowing the nested navigation to Bets → SquaresGameDetail to work properly.