### PR TITLE
Fix transaction history to only link squares bets, not regular bets

### DIFF
--- a/src/screens/BettingHistoryScreen.tsx
+++ b/src/screens/BettingHistoryScreen.tsx
@@ -54,17 +54,8 @@ export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onCl
       return;
     }
 
-    // Navigate to bet details if it's a bet transaction
-    if (transaction.relatedBetId) {
-      // Navigate first, then close modal with delay to ensure navigation completes
-      navigation.navigate('Bets', {
-        screen: 'BetDetails',
-        params: { betId: transaction.relatedBetId }
-      });
-      // Close modal after a brief delay to let navigation start
-      setTimeout(() => onClose(), 100);
-      return;
-    }
+    // Note: Regular bets (relatedBetId) don't have a detail screen yet,
+    // so we don't navigate for those transactions
   };
 
   const fetchTransactions = async () => {
@@ -213,8 +204,8 @@ interface TransactionCardProps {
 }
 
 const TransactionCard: React.FC<TransactionCardProps> = ({ transaction, onPress }) => {
-  // Check if transaction is clickable (has related bet or squares game)
-  const isClickable = !!(transaction.relatedBetId || transaction.relatedSquaresGameId);
+  // Check if transaction is clickable (only squares games have detail pages)
+  const isClickable = !!transaction.relatedSquaresGameId;
   const getTransactionIcon = (): keyof typeof Ionicons.glyphMap => {
     switch (transaction.type) {
       case 'DEPOSIT': return 'arrow-down-circle';

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -46,6 +46,7 @@ export interface Transaction {
   venmoUsername?: string;
   relatedBetId?: string;
   relatedParticipantId?: string;
+  relatedSquaresGameId?: string; // For squares game transactions
   notes?: string;
   failureReason?: string;
   processedBy?: string;


### PR DESCRIPTION
Issue: Transaction cards were clickable for both regular bets and squares bets, but only squares bets have a detail page. Regular bets were linking to a non-existent BetDetails screen.

Root cause: Transaction interface was missing relatedSquaresGameId field, and isClickable logic checked for both relatedBetId OR relatedSquaresGameId.

Solution:
- Added relatedSquaresGameId to Transaction interface in transactionService.ts (field exists in DB schema and CreateTransactionParams, but was missing from the read interface)
- Updated isClickable check to ONLY check relatedSquaresGameId
- Removed navigation code for regular bets (relatedBetId) since BetDetails screen doesn't exist yet
- Updated comments to clarify only squares transactions are clickable

Now only squares transactions (SQUARES_PURCHASE, SQUARES_PAYOUT, SQUARES_REFUND) will show the chevron and be tappable, properly linking to SquaresGameDetail.