### PR TITLE
Clear bulk loading cache after joining bet

### DIFF
--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -22,6 +22,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { NotificationService } from '../../services/notificationService';
 import { TransactionService } from '../../services/transactionService';
 import { BetAcceptanceService } from '../../services/betAcceptanceService';
+import { clearBulkLoadingCache } from '../../services/bulkLoadingService';
 import { FileDisputeModal } from '../ui/FileDisputeModal';
 import { showAlert } from '../ui/CustomAlert';
 
@@ -334,6 +335,10 @@ export const BetCard: React.FC<BetCardProps> = ({
           'Joined Successfully!',
           `You've joined the bet with $${amount}. Your new balance is $${(currentBalance - amount).toFixed(2)}.`
         );
+
+        // Clear the bulk loading cache to ensure fresh data on next fetch
+        // This fixes the issue where cached bet data shows stale participant counts
+        clearBulkLoadingCache();
 
         onJoinBet?.(bet.id, side, amount);
 


### PR DESCRIPTION
The bulkLoadingService has a 30-second cache TTL. After joining a bet, the cached bet data would still show stale participant lists, causing the bet to appear joinable even after refresh/logout.

By clearing the cache immediately after a successful join, we ensure that any subsequent data fetch will retrieve fresh data from the server with the updated participant list.

https://claude.ai/code/session_01Wc8bihUN12MfiQTcRWpUkJ