### PR TITLE
Disable caching on bet screens to fix inconsistent participant counts

### DIFF
--- a/src/screens/BetsScreen.tsx
+++ b/src/screens/BetsScreen.tsx
@@ -262,10 +262,14 @@ export const BetsScreen: React.FC = () => {
     try {
       setIsLoading(true);
 
+      // Always fetch fresh data - disable caching to ensure consistent participant counts
+      clearBulkLoadingCache();
+
       // Use bulk loading service for efficient data fetching
       const userBets = await bulkLoadUserBetsWithParticipants(user.userId, {
-        limit: 100, // Larger limit for user's own bets
-        useCache: true
+        limit: 100,
+        useCache: false,
+        forceRefresh: true
       });
 
       setBets(userBets);

--- a/src/screens/LiveEventsScreen.tsx
+++ b/src/screens/LiveEventsScreen.tsx
@@ -166,15 +166,20 @@ export const LiveEventsScreen: React.FC = () => {
         setIsLoading(true);
         console.log(`🎯 Fetching ${viewMode} bets with bulk loading for user:`, user.userId);
 
+        // Always fetch fresh data - disable caching to ensure consistent participant counts
+        clearBulkLoadingCache();
+
         // Use appropriate bulk loading service based on view mode
         const joinableBets = viewMode === 'friends'
           ? await bulkLoadFriendsBetsWithParticipants(user.userId, {
-              limit: 50, // Reasonable limit for live events
-              useCache: true
+              limit: 50,
+              useCache: false,
+              forceRefresh: true
             })
           : await bulkLoadJoinableBetsWithParticipants(user.userId, {
-              limit: 50, // Reasonable limit for live events
-              useCache: true
+              limit: 50,
+              useCache: false,
+              forceRefresh: true
             });
 
         console.log(`✅ Bulk loaded ${joinableBets.length} ${viewMode} bets`);


### PR DESCRIPTION
Both BetsScreen and LiveEventsScreen were using cached data which could show stale participant counts. This caused:
- Varying participant counts on refresh (1-0, 2-0, 2-3)
- Join page showing bets as joinable even when user already joined

Fix: Always clear cache and force refresh when loading bet data to ensure consistent participant counts from the database.

https://claude.ai/code/session_01Wc8bihUN12MfiQTcRWpUkJ