### PR TITLE
Fix Add Funds modal left-side content clipping

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -387,7 +387,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
 
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="fullScreen" onRequestClose={onClose}>
-      <SafeAreaView style={styles.container} edges={['top']}>
+      <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <KeyboardAvoidingView
           style={styles.content}
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -396,7 +396,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
 
           {/* Step Indicator */}
           <View style={styles.stepIndicator}>
-            <View style={styles.stepDot} />
+            <View style={[styles.stepDot, styles.stepDotActive]} />
             <View style={[styles.stepDot, (step === 'enter_details' || step === 'confirmation') && styles.stepDotActive]} />
             <View style={[styles.stepDot, step === 'confirmation' && styles.stepDotActive]} />
           </View>


### PR DESCRIPTION
SafeAreaView only had edges={['top']}, so left/right safe area insets
were not being applied. On devices with rounded corners or notches, this
caused content to extend into the unsafe area and get clipped on the
left side. Added 'left' and 'right' to the edges array.

Also fixed step indicator dot 1 never being marked active.

https://claude.ai/code/session_01R3nc9yc4ppGzm5vV6pEw1u