### PR TITLE
Dismiss squares invitation instantly after purchasing squares

### DIFF
--- a/src/contexts/BetDataContext.tsx
+++ b/src/contexts/BetDataContext.tsx
@@ -60,6 +60,7 @@ interface BetDataContextValue {
   acceptBetInvitation: (invitation: BetInvitation, selectedSide: string) => Promise<boolean>;
   declineBetInvitation: (invitation: BetInvitation) => Promise<void>;
   declineSquaresInvitation: (invitation: SquaresInvitation) => Promise<void>;
+  dismissSquaresInvitationByGame: (squaresGameId: string) => void;
 }
 
 const BetDataContext = createContext<BetDataContextValue | null>(null);
@@ -1060,6 +1061,18 @@ export const BetDataProvider: React.FC<{ children: React.ReactNode }> = ({ child
     }
   }, [user?.userId]);
 
+  const dismissSquaresInvitationByGameAction = useCallback((squaresGameId: string) => {
+    setSquaresInvitationsMap(prev => {
+      const updated = new Map(prev);
+      for (const [id, inv] of updated) {
+        if (inv.squaresGameId === squaresGameId) {
+          updated.delete(id);
+        }
+      }
+      return updated;
+    });
+  }, []);
+
   // ─── Context value ───────────────────────────────────────────────────────
 
   const value = useMemo<BetDataContextValue>(() => ({
@@ -1078,6 +1091,7 @@ export const BetDataProvider: React.FC<{ children: React.ReactNode }> = ({ child
     acceptBetInvitation: acceptBetInvitationAction,
     declineBetInvitation: declineBetInvitationAction,
     declineSquaresInvitation: declineSquaresInvitationAction,
+    dismissSquaresInvitationByGame: dismissSquaresInvitationByGameAction,
   }), [
     myBets,
     joinableBets,
@@ -1094,6 +1108,7 @@ export const BetDataProvider: React.FC<{ children: React.ReactNode }> = ({ child
     acceptBetInvitationAction,
     declineBetInvitationAction,
     declineSquaresInvitationAction,
+    dismissSquaresInvitationByGameAction,
   ]);
 
   return (

--- a/src/screens/SquaresGameDetailScreen.tsx
+++ b/src/screens/SquaresGameDetailScreen.tsx
@@ -19,6 +19,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { generateClient } from 'aws-amplify/data';
 import type { Schema } from '../../amplify/data/resource';
 import { useAuth } from '../contexts/AuthContext';
+import { useBetData } from '../contexts/BetDataContext';
 import { SquaresGrid } from '../components/betting/SquaresGrid';
 import { PeriodResultsCard } from '../components/betting/PeriodResultsCard';
 import { PurchaseSquaresModal } from '../components/modals/PurchaseSquaresModal';
@@ -34,6 +35,7 @@ const client = generateClient<Schema>();
 export const SquaresGameDetailScreen = ({ route, navigation }: any) => {
   const { gameId } = route.params; // Changed from squaresGameId to match navigation
   const { user } = useAuth();
+  const { dismissSquaresInvitationByGame } = useBetData();
 
   const [game, setGame] = useState<any>(null);
   const [event, setEvent] = useState<any>(null);
@@ -134,6 +136,9 @@ export const SquaresGameDetailScreen = ({ route, navigation }: any) => {
         'Purchase Successful',
         `Successfully purchased ${selectedSquares.length} square${selectedSquares.length > 1 ? 's' : ''} for ${ownerName}!`
       );
+
+      // Remove invitation card immediately (service already auto-accepted in DB)
+      dismissSquaresInvitationByGame(game.id);
 
       // Refresh data
       loadGameData();


### PR DESCRIPTION
The invitation card now disappears immediately when a user buys squares in an invited game, without requiring a manual refresh. Added dismissSquaresInvitationByGame to BetDataContext for optimistic local state removal, called from SquaresGameDetailScreen after purchase.

https://claude.ai/code/session_014K5Q7TUro5N9eqRQ3utGDp