### PR TITLE
Fix left-side clipping on PaymentMethods and WithdrawFunds screens

### DIFF
--- a/src/components/ui/WithdrawFundsModal.tsx
+++ b/src/components/ui/WithdrawFundsModal.tsx
@@ -453,7 +453,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
 
   return (
     <Modal visible={visible} animationType="slide" presentationStyle="fullScreen" onRequestClose={onClose}>
-      <SafeAreaView style={styles.container} edges={['top']}>
+      <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <KeyboardAvoidingView
           style={styles.content}
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -462,7 +462,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
 
           {/* Step Indicator */}
           <View style={styles.stepIndicator}>
-            <View style={styles.stepDot} />
+            <View style={[styles.stepDot, styles.stepDotActive]} />
             <View style={[styles.stepDot, (step === 'enter_amount' || step === 'confirmation') && styles.stepDotActive]} />
             <View style={[styles.stepDot, step === 'confirmation' && styles.stepDotActive]} />
           </View>

--- a/src/screens/PaymentMethodsScreen.tsx
+++ b/src/screens/PaymentMethodsScreen.tsx
@@ -158,7 +158,7 @@ export const PaymentMethodsScreen: React.FC<PaymentMethodsScreenProps> = ({ onCl
 
   if (isLoading) {
     return (
-      <SafeAreaView style={styles.container} edges={['top']}>
+      <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <ModalHeader title="Payment Methods" onClose={onClose} />
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
@@ -168,7 +168,7 @@ export const PaymentMethodsScreen: React.FC<PaymentMethodsScreenProps> = ({ onCl
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <ModalHeader title="Payment Methods" onClose={onClose} />
 
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>


### PR DESCRIPTION
Same SafeAreaView edges={['top']} issue as AddFundsModal — on devices with curved screens (Samsung etc.), left/right safe area insets are non-zero and content was rendering behind the curved edges.

Added 'left' and 'right' to SafeAreaView edges on:
- PaymentMethodsScreen (both loading and main views)
- WithdrawFundsModal

Also fixed first step dot never being active in WithdrawFundsModal.

https://claude.ai/code/session_01R3nc9yc4ppGzm5vV6pEw1u