### PR TITLE
Fix left-side content clipping on Add/Withdraw Funds modals

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -390,7 +390,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
       <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <KeyboardAvoidingView
           style={styles.content}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
           <ModalHeader title="Add Funds" onClose={onClose} />
 
@@ -444,7 +444,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   stepContentContainer: {
-    padding: spacing.lg,
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
   },
   sectionTitle: {
     ...textStyles.label,

--- a/src/components/ui/WithdrawFundsModal.tsx
+++ b/src/components/ui/WithdrawFundsModal.tsx
@@ -193,7 +193,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   };
 
   const renderSelectMethod = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>SELECT VENMO ACCOUNT</Text>
 
       {isLoadingMethods ? (
@@ -265,7 +265,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   );
 
   const renderEnterAmount = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>WITHDRAWAL DETAILS</Text>
 
       {/* Available Balance */}
@@ -380,7 +380,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   );
 
   const renderConfirmation = () => (
-    <ScrollView style={styles.stepContent} showsVerticalScrollIndicator={false}>
+    <ScrollView style={styles.stepContent} contentContainerStyle={styles.stepContentContainer} showsVerticalScrollIndicator={false}>
       <Text style={styles.sectionTitle}>CONFIRM WITHDRAWAL</Text>
 
       {/* Summary Card */}
@@ -456,7 +456,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
       <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
         <KeyboardAvoidingView
           style={styles.content}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
           <ModalHeader title="Withdraw Funds" onClose={onClose} />
 
@@ -508,7 +508,10 @@ const styles = StyleSheet.create({
   // Content
   stepContent: {
     flex: 1,
-    padding: spacing.lg,
+  },
+  stepContentContainer: {
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
   },
   sectionTitle: {
     ...textStyles.label,


### PR DESCRIPTION
Two root causes addressed:

1. WithdrawFundsModal had padding on ScrollView's style prop instead of contentContainerStyle. On Android, padding on ScrollView style clips content in the padding area. Moved padding to contentContainerStyle on all three step ScrollViews.

2. Both modals used KeyboardAvoidingView with behavior='height' on Android. This sets an explicit height that can interfere with flex layout. Changed to behavior=undefined on Android since the system handles keyboard avoidance via windowSoftInputMode.

Also increased horizontal padding from spacing.lg (24) to spacing.xl (32) on both modals for better content inset.

https://claude.ai/code/session_01R3nc9yc4ppGzm5vV6pEw1u