### PR TITLE
Fix amount input focus extending beyond container bounds

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -537,6 +537,7 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     borderRadius: spacing.radius.md,
     paddingHorizontal: spacing.md,
+    overflow: 'hidden',
   },
   currencySymbol: {
     ...textStyles.h2,

--- a/src/components/ui/WithdrawFundsModal.tsx
+++ b/src/components/ui/WithdrawFundsModal.tsx
@@ -624,6 +624,7 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     borderRadius: spacing.radius.md,
     paddingHorizontal: spacing.md,
+    overflow: 'hidden',
   },
   currencySymbol: {
     ...textStyles.h2,


### PR DESCRIPTION
The TextInput with h2 font size and flex:1 was extending its selection/cursor highlight beyond the container on focus, pushing the entire layout wider than the screen and clipping the left side.

Added overflow: 'hidden' to amountInputContainer on both AddFundsModal and WithdrawFundsModal to contain the input's focus area within its bounds.

https://claude.ai/code/session_01R3nc9yc4ppGzm5vV6pEw1u