### PR TITLE
Fix FriendSelector section styling to match CreateBetScreen layout

### DIFF
--- a/src/components/ui/FriendSelector.tsx
+++ b/src/components/ui/FriendSelector.tsx
@@ -125,17 +125,20 @@ export const FriendSelector: React.FC<FriendSelectorProps> = ({
 
 const styles = StyleSheet.create({
   section: {
-    marginBottom: spacing.lg,
+    padding: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
   },
   sectionTitle: {
-    ...textStyles.label,
-    color: colors.textSecondary,
-    marginBottom: spacing.xs / 2,
+    ...textStyles.h3,
+    color: colors.textPrimary,
+    marginBottom: spacing.xs,
+    fontWeight: typography.fontWeight.bold,
   },
   sectionSubtitle: {
     ...textStyles.caption,
     color: colors.textMuted,
-    marginBottom: spacing.sm,
+    marginBottom: spacing.md,
   },
   friendsScroll: {
     marginTop: spacing.md,


### PR DESCRIPTION
The FriendSelector component used its own inconsistent section styles
(label typography, no padding, no border). Updated to use the same
section pattern as CreateBetScreen: h3 title, primary text color,
horizontal padding, and bottom border separator.

https://claude.ai/code/session_011dp2UcuqyngiKFV3xh9yYZ