### PR TITLE
Denormalize creator name on Bet model for efficiency

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -198,6 +198,7 @@ const schema = a.schema({
       category: a.enum(['SPORTS', 'ENTERTAINMENT', 'WEATHER', 'STOCKS', 'CUSTOM']),
       status: a.enum(['DRAFT', 'ACTIVE', 'LIVE', 'PENDING_RESOLUTION', 'DISPUTED', 'RESOLVED', 'CANCELLED']),
       creatorId: a.id().required(),
+      creatorName: a.string(), // Denormalized creator display name for efficient rendering
       totalPot: a.float().required(),
       betAmount: a.float(), // Individual bet amount for joining
       odds: a.json(), // Store odds as JSON object

--- a/src/components/betting/BetCard.tsx
+++ b/src/components/betting/BetCard.tsx
@@ -427,7 +427,7 @@ export const BetCard: React.FC<BetCardProps> = ({
 
   // Determine if user is creator
   const isCreator = user && bet.creatorId === user.userId;
-  const creatorName = bet.creator?.displayName || bet.creator?.username || 'Unknown';
+  const creatorName = bet.creatorName || 'Unknown';
 
   // Check if bet is active
   const isActive = bet.status === 'ACTIVE';

--- a/src/components/betting/BetList.tsx
+++ b/src/components/betting/BetList.tsx
@@ -65,7 +65,7 @@ export const BetList: React.FC<BetListProps> = ({
       filtered = filtered.filter(bet =>
         bet.title.toLowerCase().includes(query) ||
         bet.description.toLowerCase().includes(query) ||
-        bet.creator?.username.toLowerCase().includes(query)
+        bet.creatorName?.toLowerCase().includes(query)
       );
     }
 

--- a/src/screens/AdminTestingScreen.tsx
+++ b/src/screens/AdminTestingScreen.tsx
@@ -435,6 +435,7 @@ export const AdminTestingScreen: React.FC<{ onClose: () => void }> = ({ onClose 
           category: 'CUSTOM',
           status: 'ACTIVE',
           creatorId: testUserId, // Test user is creator, not you
+          creatorName: 'Test User',
           totalPot: 0, // No one joined yet
           betAmount: 10,
           odds: JSON.stringify({

--- a/src/screens/CreateBetScreen.tsx
+++ b/src/screens/CreateBetScreen.tsx
@@ -393,6 +393,7 @@ export const CreateBetScreen: React.FC = () => {
         category: selectedCategory as Schema['Bet']['type']['category'],
         status: 'ACTIVE',
         creatorId: user.userId,
+        creatorName: user.displayName || user.username,
         totalPot: amount,
         betAmount: amount, // Store the individual bet amount for joining
         odds: oddsObject,

--- a/src/types/betting.ts
+++ b/src/types/betting.ts
@@ -26,7 +26,7 @@ export interface Bet {
   category: BetCategory;
   status: BetStatus;
   creatorId: string;
-  creator?: User;
+  creatorName?: string; // Denormalized creator display name
   totalPot: number;
   betAmount?: number;
   odds: BetOdds;


### PR DESCRIPTION
Changed from complex user enrichment queries to simple denormalized creatorName field stored at bet creation. This follows the existing pattern of denormalizing participantUserIds/counts and eliminates N additional queries on bet list loads.

- Schema: Added creatorName field to Bet model
- Creation: Store displayName || username when creating bets
- UI: Simplified BetCard and BetList to use creatorName directly
- Context: Removed all async enrichment logic from BetDataContext

https://claude.ai/code/session_01SQFFv2HmLKrXbpEtMUsZiH