### PR TITLE
Properly fix amount input overflow with visible focus state

### DIFF
--- a/src/components/ui/AddFundsModal.tsx
+++ b/src/components/ui/AddFundsModal.tsx
@@ -51,6 +51,7 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [step, setStep] = useState<'select_method' | 'enter_details' | 'confirmation'>('select_method');
+  const [amountFocused, setAmountFocused] = useState(false);
 
   // Load payment methods when modal opens
   useEffect(() => {
@@ -252,17 +253,21 @@ export const AddFundsModal: React.FC<AddFundsModalProps> = ({
       {/* Amount Input */}
       <View style={styles.inputSection}>
         <Text style={styles.inputLabel}>Amount to Deposit</Text>
-        <View style={styles.amountInputContainer}>
+        <View style={[styles.amountInputContainer, amountFocused && styles.amountInputContainerFocused]}>
           <Text style={styles.currencySymbol}>$</Text>
-          <TextInput
-            style={styles.amountInput}
-            placeholder="0.00"
-            placeholderTextColor={colors.textMuted}
-            keyboardType="decimal-pad"
-            value={amount}
-            onChangeText={setAmount}
-            autoFocus
-          />
+          <View style={styles.amountInputWrapper}>
+            <TextInput
+              style={styles.amountInput}
+              placeholder="0.00"
+              placeholderTextColor={colors.textMuted}
+              keyboardType="decimal-pad"
+              value={amount}
+              onChangeText={setAmount}
+              onFocus={() => setAmountFocused(true)}
+              onBlur={() => setAmountFocused(false)}
+              autoFocus
+            />
+          </View>
         </View>
         <Text style={styles.inputHint}>
           Min: ${MIN_DEPOSIT.toFixed(2)} • Max: ${MAX_DEPOSIT.toFixed(2)}
@@ -533,10 +538,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: colors.surface,
-    borderWidth: 1,
+    borderWidth: 2,
     borderColor: colors.border,
     borderRadius: spacing.radius.md,
     paddingHorizontal: spacing.md,
+  },
+  amountInputContainerFocused: {
+    borderColor: colors.primary,
   },
   currencySymbol: {
     fontSize: typography.fontSize['2xl'],
@@ -544,8 +552,11 @@ const styles = StyleSheet.create({
     fontWeight: typography.fontWeight.bold,
     fontFamily: typography.fontFamily.bold,
   },
-  amountInput: {
+  amountInputWrapper: {
     flex: 1,
+    overflow: 'hidden',
+  },
+  amountInput: {
     fontSize: typography.fontSize['2xl'],
     color: colors.textPrimary,
     fontWeight: typography.fontWeight.bold,

--- a/src/components/ui/WithdrawFundsModal.tsx
+++ b/src/components/ui/WithdrawFundsModal.tsx
@@ -51,6 +51,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   const [isLoadingMethods, setIsLoadingMethods] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [step, setStep] = useState<'select_method' | 'enter_amount' | 'confirmation'>('select_method');
+  const [amountFocused, setAmountFocused] = useState(false);
 
   // Load payment methods and user balance when modal opens
   useEffect(() => {
@@ -277,17 +278,21 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
       {/* Amount Input */}
       <View style={styles.inputSection}>
         <Text style={styles.inputLabel}>Amount to Withdraw</Text>
-        <View style={styles.amountInputContainer}>
+        <View style={[styles.amountInputContainer, amountFocused && styles.amountInputContainerFocused]}>
           <Text style={styles.currencySymbol}>$</Text>
-          <TextInput
-            style={styles.amountInput}
-            placeholder="0.00"
-            placeholderTextColor={colors.textMuted}
-            keyboardType="decimal-pad"
-            value={amount}
-            onChangeText={setAmount}
-            autoFocus
-          />
+          <View style={styles.amountInputWrapper}>
+            <TextInput
+              style={styles.amountInput}
+              placeholder="0.00"
+              placeholderTextColor={colors.textMuted}
+              keyboardType="decimal-pad"
+              value={amount}
+              onChangeText={setAmount}
+              onFocus={() => setAmountFocused(true)}
+              onBlur={() => setAmountFocused(false)}
+              autoFocus
+            />
+          </View>
         </View>
         <Text style={styles.inputHint}>
           Min: {formatCurrency(MIN_WITHDRAWAL)} • Available: {formatCurrency(userBalance)}
@@ -620,10 +625,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: colors.surface,
-    borderWidth: 1,
+    borderWidth: 2,
     borderColor: colors.border,
     borderRadius: spacing.radius.md,
     paddingHorizontal: spacing.md,
+  },
+  amountInputContainerFocused: {
+    borderColor: colors.primary,
   },
   currencySymbol: {
     fontSize: typography.fontSize['2xl'],
@@ -631,8 +639,11 @@ const styles = StyleSheet.create({
     fontWeight: typography.fontWeight.bold,
     fontFamily: typography.fontFamily.bold,
   },
-  amountInput: {
+  amountInputWrapper: {
     flex: 1,
+    overflow: 'hidden',
+  },
+  amountInput: {
     fontSize: typography.fontSize['2xl'],
     color: colors.textPrimary,
     fontWeight: typography.fontWeight.bold,


### PR DESCRIPTION
Instead of hiding overflow on the entire container (which killed focus feedback), wrap just the TextInput in a flex:1 overflow:hidden View that contains the Android cursor/selection handle overflow.

Added a proper focus indicator: the container border changes to primary color (yellow) on focus via onFocus/onBlur state. Border bumped from 1px to 2px for clear visibility. This is better UX than relying on Android's default TextInput decorations.

https://claude.ai/code/session_01R3nc9yc4ppGzm5vV6pEw1u