### PR TITLE
Fix creatorName to use displayName only, not Cognito hash

### DIFF
--- a/src/screens/CreateBetScreen.tsx
+++ b/src/screens/CreateBetScreen.tsx
@@ -393,7 +393,7 @@ export const CreateBetScreen: React.FC = () => {
         category: selectedCategory as Schema['Bet']['type']['category'],
         status: 'ACTIVE',
         creatorId: user.userId,
-        creatorName: user.displayName || user.username,
+        creatorName: user.displayName || 'User',
         totalPot: amount,
         betAmount: amount, // Store the individual bet amount for joining
         odds: oddsObject,


### PR DESCRIPTION
The user.username field from AuthContext contains the Cognito username (a 32-char hash), not a friendly name. Changed creatorName to use only displayName with a fallback to 'User' instead of the hash.

https://claude.ai/code/session_01SQFFv2HmLKrXbpEtMUsZiH