### PR TITLE
Fix account and profile page layout issues

### DIFF
--- a/src/components/ui/ProfileEditor.tsx
+++ b/src/components/ui/ProfileEditor.tsx
@@ -186,6 +186,15 @@ export const ProfileEditor: React.FC<ProfileEditorProps> = ({
             <Text style={styles.readOnlyHelper}>Username cannot be changed</Text>
           </View>
         </View>
+
+        {/* Email Display (Read-only) */}
+        <View style={styles.inputSection}>
+          <Text style={styles.inputLabel}>Email</Text>
+          <View style={styles.readOnlyContainer}>
+            <Text style={styles.readOnlyText}>{user.email}</Text>
+            <Text style={styles.readOnlyHelper}>Email cannot be changed</Text>
+          </View>
+        </View>
       </View>
 
       {/* Action Buttons */}

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -374,13 +374,20 @@ export const AccountScreen: React.FC = () => {
     try {
       setIsUpdatingProfile(true);
 
-      // Update user profile in database
-      const updatedUser = await client.models.User.update({
+      // Build update object - only include fields that are being changed
+      const updateData: any = {
         id: userProfile.id,
         displayName: profileData.displayName,
         displayNameLower: profileData.displayName ? profileData.displayName.toLowerCase() : undefined,
-        profilePictureUrl: profileData.profilePicture,
-      });
+      };
+
+      // Only update profile picture if it's explicitly provided and different from current
+      if (profileData.profilePicture !== undefined && profileData.profilePicture !== userProfile.profilePictureUrl) {
+        updateData.profilePictureUrl = profileData.profilePicture;
+      }
+
+      // Update user profile in database
+      const updatedUser = await client.models.User.update(updateData);
 
       if (updatedUser.data) {
         // Update local state
@@ -500,7 +507,6 @@ export const AccountScreen: React.FC = () => {
                   {userProfile.displayName || 'Set Display Name'}
                 </Text>
               </TouchableOpacity>
-              <Text style={styles.email}>{userProfile.email}</Text>
 
               {/* Balance Breakdown */}
               <View style={styles.balanceBreakdown}>
@@ -514,11 +520,10 @@ export const AccountScreen: React.FC = () => {
                     <Text style={styles.pendingValue}>${pendingPayouts.toFixed(2)}</Text>
                   </View>
                 )}
-              </View>
-
-              <View style={styles.trustContainer}>
-                <Text style={styles.trustLabel}>Trust Score</Text>
-                <Text style={styles.trustScore}>{userProfile.trustScore.toFixed(1)}/10</Text>
+                <View style={styles.balanceRow}>
+                  <Text style={styles.balanceLabel}>Trust Score:</Text>
+                  <Text style={styles.trustScore}>{userProfile.trustScore.toFixed(1)}/10</Text>
+                </View>
               </View>
             </View>
           </View>
@@ -957,11 +962,6 @@ const styles = StyleSheet.create({
     marginBottom: spacing.xs,
     fontWeight: '700',
   },
-  email: {
-    ...textStyles.body,
-    color: colors.textSecondary,
-    marginBottom: spacing.xs,
-  },
   balanceBreakdown: {
     marginVertical: spacing.xs,
     paddingVertical: spacing.xs,
@@ -988,15 +988,6 @@ const styles = StyleSheet.create({
     ...textStyles.button,
     color: colors.warning,
     fontWeight: '600',
-  },
-  trustContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  trustLabel: {
-    ...textStyles.caption,
-    color: colors.textMuted,
-    marginRight: spacing.xs,
   },
   trustScore: {
     ...textStyles.button,


### PR DESCRIPTION
- Move email display from account page to profile editor (read-only)
- Fix profile picture save logic to prevent null overwrites when only updating display name
- Redesign trust score layout to align with balance breakdown rows
- Remove unused styles (email, trustContainer, trustLabel)

Profile picture and display name now save independently without affecting each other.

https://claude.ai/code/session_018fuLmtzLog2XatZ5wLx5nc