### PR TITLE
Add bet details page for troubleshooting from betting history

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -24,6 +24,7 @@ import { ResolveScreen } from '../screens/ResolveScreen';
 import { AccountScreen } from '../screens/AccountScreen';
 import { OnboardingScreen } from '../screens/OnboardingScreen';
 import { SquaresGameDetailScreen } from '../screens/SquaresGameDetailScreen';
+import { BetDetailsScreen } from '../screens/BetDetailsScreen';
 
 // Create navigators
 const Tab = createBottomTabNavigator<AppTabParamList>();
@@ -49,6 +50,11 @@ const BetsStackNavigator = () => {
         name="BetsList"
         component={BetsScreen}
         options={{ headerShown: false }} // We'll use custom header
+      />
+      <BetsStack.Screen
+        name="BetDetails"
+        component={BetDetailsScreen}
+        options={{ headerShown: false }}
       />
       <BetsStack.Screen
         name="SquaresGameDetail"

--- a/src/screens/BetDetailsScreen.tsx
+++ b/src/screens/BetDetailsScreen.tsx
@@ -1,0 +1,749 @@
+/**
+ * Bet Details Screen
+ * Shows full bet info, sides breakdown, user participation, and debug IDs
+ * Navigated to from Betting History when tapping a bet transaction
+ */
+
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { StackScreenProps } from '@react-navigation/stack';
+import { generateClient } from 'aws-amplify/data';
+import type { Schema } from '../../amplify/data/resource';
+import { BetsStackParamList } from '../types/navigation';
+import { colors, spacing, textStyles, typography, shadows } from '../styles';
+import { useAuth } from '../contexts/AuthContext';
+import { formatCurrency, formatCategory } from '../utils/formatting';
+
+const client = generateClient<Schema>();
+
+type Props = StackScreenProps<BetsStackParamList, 'BetDetails'>;
+
+interface BetData {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  status: string;
+  creatorId: string;
+  creatorName?: string;
+  totalPot: number;
+  betAmount?: number;
+  odds: { sideAName: string; sideBName: string };
+  deadline: string;
+  winningSide?: string;
+  resolutionReason?: string;
+  sideACount: number;
+  sideBCount: number;
+  participantUserIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ParticipantData {
+  id: string;
+  side: string;
+  amount: number;
+  payout: number;
+  joinedAt: string;
+}
+
+export const BetDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
+  const { betId } = route.params;
+  const { user } = useAuth();
+  const [bet, setBet] = useState<BetData | null>(null);
+  const [participant, setParticipant] = useState<ParticipantData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadBetDetails();
+  }, [betId]);
+
+  const loadBetDetails = async () => {
+    if (!user?.userId) return;
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const [betResult, participantsResult] = await Promise.all([
+        client.models.Bet.get({ id: betId }),
+        client.models.Participant.list({
+          filter: { betId: { eq: betId }, userId: { eq: user.userId } },
+        }),
+      ]);
+
+      if (betResult.data) {
+        const raw = betResult.data;
+        setBet({
+          id: raw.id,
+          title: raw.title,
+          description: raw.description,
+          category: raw.category || 'CUSTOM',
+          status: raw.status || 'ACTIVE',
+          creatorId: raw.creatorId,
+          creatorName: raw.creatorName || undefined,
+          totalPot: raw.totalPot,
+          betAmount: raw.betAmount || undefined,
+          odds: (raw.odds as { sideAName: string; sideBName: string }) || {
+            sideAName: 'Side A',
+            sideBName: 'Side B',
+          },
+          deadline: raw.deadline,
+          winningSide: raw.winningSide || undefined,
+          resolutionReason: raw.resolutionReason || undefined,
+          sideACount: raw.sideACount || 0,
+          sideBCount: raw.sideBCount || 0,
+          participantUserIds: (raw.participantUserIds?.filter(Boolean) as string[]) || [],
+          createdAt: raw.createdAt || '',
+          updatedAt: raw.updatedAt || '',
+        });
+      } else {
+        setError('Bet not found');
+      }
+
+      if (participantsResult.data && participantsResult.data.length > 0) {
+        const p = participantsResult.data[0];
+        setParticipant({
+          id: p.id,
+          side: p.side,
+          amount: p.amount,
+          payout: p.payout || 0,
+          joinedAt: p.joinedAt || '',
+        });
+      }
+    } catch (err) {
+      console.error('[BetDetails] Error loading bet:', err);
+      setError('Failed to load bet details');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getUserResult = (): 'WON' | 'LOST' | null => {
+    if (!bet || !participant || bet.status !== 'RESOLVED' || !bet.winningSide) return null;
+    return participant.side === bet.winningSide ? 'WON' : 'LOST';
+  };
+
+  const getStatusColor = (status: string): string => {
+    switch (status) {
+      case 'ACTIVE': return colors.success;
+      case 'LIVE': return colors.live;
+      case 'PENDING_RESOLUTION': return colors.warning;
+      case 'RESOLVED': return colors.primary;
+      case 'CANCELLED': return colors.textMuted;
+      case 'DISPUTED': return colors.error;
+      default: return colors.textSecondary;
+    }
+  };
+
+  const getStatusLabel = (status: string): string => {
+    switch (status) {
+      case 'ACTIVE': return 'ACTIVE';
+      case 'LIVE': return 'LIVE';
+      case 'PENDING_RESOLUTION': return 'PENDING RESOLUTION';
+      case 'RESOLVED': return 'RESOLVED';
+      case 'CANCELLED': return 'CANCELLED';
+      case 'DISPUTED': return 'DISPUTED';
+      default: return status;
+    }
+  };
+
+  const formatDate = (dateStr: string): string => {
+    if (!dateStr) return 'N/A';
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  const renderHeader = () => (
+    <View style={styles.header}>
+      <TouchableOpacity
+        style={styles.backButton}
+        onPress={() => navigation.goBack()}
+        activeOpacity={0.7}
+      >
+        <Ionicons name="chevron-back" size={24} color={colors.textPrimary} />
+      </TouchableOpacity>
+      <Text style={styles.headerTitle}>Bet Details</Text>
+      <View style={styles.headerRight} />
+    </View>
+  );
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        {renderHeader()}
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !bet) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        {renderHeader()}
+        <View style={styles.centered}>
+          <Ionicons name="alert-circle-outline" size={48} color={colors.textMuted} />
+          <Text style={styles.errorText}>{error || 'Bet not found'}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={loadBetDetails} activeOpacity={0.7}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const sideAName = bet.odds?.sideAName || 'Side A';
+  const sideBName = bet.odds?.sideBName || 'Side B';
+  const isCreator = user?.userId === bet.creatorId;
+  const userResult = getUserResult();
+  const totalParticipants = (bet.sideACount || 0) + (bet.sideBCount || 0);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      {renderHeader()}
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+
+        {/* User Result Hero */}
+        {userResult && (
+          <View style={[
+            styles.resultHero,
+            { backgroundColor: userResult === 'WON' ? colors.success + '20' : colors.error + '20' },
+          ]}>
+            <Ionicons
+              name={userResult === 'WON' ? 'trophy' : 'close-circle'}
+              size={40}
+              color={userResult === 'WON' ? colors.success : colors.error}
+            />
+            <Text style={[
+              styles.resultText,
+              { color: userResult === 'WON' ? colors.success : colors.error },
+            ]}>
+              YOU {userResult}
+            </Text>
+            {userResult === 'WON' && participant && participant.payout > 0 && (
+              <Text style={styles.resultSubtext}>
+                Payout: {formatCurrency(participant.payout)}
+              </Text>
+            )}
+          </View>
+        )}
+
+        {/* Status & Bet Info */}
+        <View style={styles.card}>
+          <View style={styles.badgeRow}>
+            <View style={[styles.statusBadge, { backgroundColor: getStatusColor(bet.status) + '20' }]}>
+              <Text style={[styles.statusBadgeText, { color: getStatusColor(bet.status) }]}>
+                {getStatusLabel(bet.status)}
+              </Text>
+            </View>
+            {isCreator && (
+              <View style={styles.creatorBadge}>
+                <Text style={styles.creatorBadgeText}>CREATOR</Text>
+              </View>
+            )}
+          </View>
+
+          <Text style={styles.betTitle}>{bet.title}</Text>
+          {!!bet.description && (
+            <Text style={styles.betDescription}>{bet.description}</Text>
+          )}
+
+          <View style={styles.divider} />
+
+          <View style={styles.infoGrid}>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Category</Text>
+              <Text style={styles.infoValue}>{formatCategory(bet.category)}</Text>
+            </View>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Bet Amount</Text>
+              <Text style={styles.infoValue}>
+                {bet.betAmount ? formatCurrency(bet.betAmount) : 'Open'}
+              </Text>
+            </View>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Total Pot</Text>
+              <Text style={[styles.infoValue, { color: colors.primary }]}>
+                {formatCurrency(bet.totalPot)}
+              </Text>
+            </View>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Participants</Text>
+              <Text style={styles.infoValue}>{totalParticipants}</Text>
+            </View>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Created</Text>
+              <Text style={styles.infoValue}>{formatDate(bet.createdAt)}</Text>
+            </View>
+            <View style={styles.infoItem}>
+              <Text style={styles.infoLabel}>Deadline</Text>
+              <Text style={styles.infoValue}>{formatDate(bet.deadline)}</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Sides Breakdown */}
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Sides</Text>
+
+          <View style={[
+            styles.sideRow,
+            bet.winningSide === 'A' && styles.winningSideRow,
+            participant?.side === 'A' && !bet.winningSide && styles.yourSideRow,
+          ]}>
+            <View style={styles.sideInfo}>
+              <View style={styles.sideLabelRow}>
+                <Text style={styles.sideLabel}>{sideAName}</Text>
+                {participant?.side === 'A' && (
+                  <View style={styles.yourSideBadge}>
+                    <Text style={styles.yourSideBadgeText}>YOUR SIDE</Text>
+                  </View>
+                )}
+                {bet.winningSide === 'A' && (
+                  <View style={[styles.winnerBadge]}>
+                    <Ionicons name="trophy" size={10} color={colors.success} />
+                    <Text style={styles.winnerBadgeText}>WINNER</Text>
+                  </View>
+                )}
+              </View>
+              <Text style={styles.sideCount}>
+                {bet.sideACount || 0} participant{bet.sideACount !== 1 ? 's' : ''}
+              </Text>
+            </View>
+            <Text style={styles.sideLetter}>A</Text>
+          </View>
+
+          <View style={styles.vsDivider}>
+            <View style={styles.vsDividerLine} />
+            <Text style={styles.vsText}>VS</Text>
+            <View style={styles.vsDividerLine} />
+          </View>
+
+          <View style={[
+            styles.sideRow,
+            bet.winningSide === 'B' && styles.winningSideRow,
+            participant?.side === 'B' && !bet.winningSide && styles.yourSideRow,
+          ]}>
+            <View style={styles.sideInfo}>
+              <View style={styles.sideLabelRow}>
+                <Text style={styles.sideLabel}>{sideBName}</Text>
+                {participant?.side === 'B' && (
+                  <View style={styles.yourSideBadge}>
+                    <Text style={styles.yourSideBadgeText}>YOUR SIDE</Text>
+                  </View>
+                )}
+                {bet.winningSide === 'B' && (
+                  <View style={styles.winnerBadge}>
+                    <Ionicons name="trophy" size={10} color={colors.success} />
+                    <Text style={styles.winnerBadgeText}>WINNER</Text>
+                  </View>
+                )}
+              </View>
+              <Text style={styles.sideCount}>
+                {bet.sideBCount || 0} participant{bet.sideBCount !== 1 ? 's' : ''}
+              </Text>
+            </View>
+            <Text style={styles.sideLetter}>B</Text>
+          </View>
+
+          {!!bet.resolutionReason && (
+            <>
+              <View style={styles.divider} />
+              <Text style={styles.infoLabel}>Resolution Reason</Text>
+              <Text style={styles.resolutionReason}>{bet.resolutionReason}</Text>
+            </>
+          )}
+        </View>
+
+        {/* Your Participation */}
+        {participant && (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Your Participation</Text>
+            <View style={styles.infoGrid}>
+              <View style={styles.infoItem}>
+                <Text style={styles.infoLabel}>Your Side</Text>
+                <Text style={styles.infoValue}>
+                  {participant.side === 'A' ? sideAName : sideBName}{' '}
+                  <Text style={styles.sideLetterInline}>({participant.side})</Text>
+                </Text>
+              </View>
+              <View style={styles.infoItem}>
+                <Text style={styles.infoLabel}>Amount Bet</Text>
+                <Text style={styles.infoValue}>{formatCurrency(participant.amount)}</Text>
+              </View>
+              {bet.status === 'RESOLVED' && (
+                <View style={styles.infoItem}>
+                  <Text style={styles.infoLabel}>Payout</Text>
+                  <Text style={[
+                    styles.infoValue,
+                    { color: userResult === 'WON' ? colors.success : colors.textMuted },
+                  ]}>
+                    {userResult === 'WON' ? formatCurrency(participant.payout) : formatCurrency(0)}
+                  </Text>
+                </View>
+              )}
+              <View style={styles.infoItem}>
+                <Text style={styles.infoLabel}>Joined</Text>
+                <Text style={styles.infoValue}>{formatDate(participant.joinedAt)}</Text>
+              </View>
+            </View>
+          </View>
+        )}
+
+        {/* Debug / ID Section */}
+        <View style={styles.card}>
+          <View style={styles.cardTitleRow}>
+            <Ionicons name="bug-outline" size={14} color={colors.textMuted} />
+            <Text style={[styles.cardTitle, { marginLeft: spacing.xs / 2, color: colors.textMuted }]}>
+              Debug Info
+            </Text>
+          </View>
+
+          <IdRow label="Bet ID" value={bet.id} />
+          <IdRow label="Creator ID" value={bet.creatorId} />
+          {bet.creatorName && <IdRow label="Creator Name" value={bet.creatorName} />}
+          {participant && <IdRow label="Participant ID" value={participant.id} />}
+          {bet.winningSide && (
+            <IdRow label="Winning Side" value={`${bet.winningSide} (${bet.winningSide === 'A' ? sideAName : sideBName})`} />
+          )}
+          <IdRow label="Stored Participant IDs" value={`${bet.participantUserIds.length} total`} />
+          <IdRow label="Last Updated" value={formatDate(bet.updatedAt)} mono={false} />
+        </View>
+
+        <View style={styles.bottomPad} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+// Reusable ID row for the debug section
+const IdRow: React.FC<{ label: string; value: string; mono?: boolean }> = ({
+  label,
+  value,
+  mono = true,
+}) => (
+  <View style={styles.idRow}>
+    <Text style={styles.idLabel}>{label}</Text>
+    <Text style={[styles.idValue, !mono && styles.idValuePlain]} selectable>
+      {value}
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    minHeight: 60,
+  },
+  backButton: {
+    padding: spacing.xs,
+    width: 40,
+  },
+  headerTitle: {
+    ...textStyles.h3,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+  },
+  headerRight: {
+    width: 40,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+  },
+  errorText: {
+    ...textStyles.body,
+    color: colors.textMuted,
+    marginTop: spacing.md,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: spacing.radius.md,
+    backgroundColor: colors.primary,
+  },
+  retryButtonText: {
+    ...textStyles.button,
+    color: colors.background,
+    fontWeight: typography.fontWeight.semibold,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+
+  // Result hero
+  resultHero: {
+    borderRadius: spacing.radius.lg,
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  resultText: {
+    ...textStyles.h2,
+    fontWeight: typography.fontWeight.black,
+    marginTop: spacing.sm,
+  },
+  resultSubtext: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    marginTop: spacing.xs,
+  },
+
+  // Cards
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: spacing.radius.lg,
+    padding: spacing.md,
+    marginBottom: spacing.md,
+    ...shadows.card,
+  },
+  cardTitle: {
+    ...textStyles.label,
+    color: colors.textSecondary,
+    fontWeight: typography.fontWeight.semibold,
+    textTransform: 'uppercase',
+    fontSize: 11,
+    marginBottom: spacing.sm,
+  },
+  cardTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+
+  // Badges row
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+    borderRadius: spacing.radius.sm,
+    marginRight: spacing.xs,
+  },
+  statusBadgeText: {
+    ...textStyles.caption,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: 11,
+    textTransform: 'uppercase',
+  },
+  creatorBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+    borderRadius: spacing.radius.sm,
+    backgroundColor: colors.primary + '20',
+  },
+  creatorBadgeText: {
+    ...textStyles.caption,
+    color: colors.primary,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: 11,
+    textTransform: 'uppercase',
+  },
+
+  // Bet info
+  betTitle: {
+    ...textStyles.h3,
+    color: colors.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  betDescription: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    lineHeight: 20,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: spacing.sm,
+  },
+  infoGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  infoItem: {
+    width: '50%',
+    marginBottom: spacing.sm,
+  },
+  infoLabel: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    fontSize: 11,
+    marginBottom: 2,
+  },
+  infoValue: {
+    ...textStyles.body,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.medium,
+    fontSize: typography.fontSize.sm,
+  },
+  sideLetterInline: {
+    color: colors.textMuted,
+    fontWeight: typography.fontWeight.normal,
+  },
+
+  // Sides
+  sideRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    borderRadius: spacing.radius.md,
+    backgroundColor: colors.background,
+  },
+  winningSideRow: {
+    backgroundColor: colors.success + '15',
+    borderWidth: 1,
+    borderColor: colors.success + '40',
+  },
+  yourSideRow: {
+    backgroundColor: colors.primary + '15',
+    borderWidth: 1,
+    borderColor: colors.primary + '40',
+  },
+  sideInfo: {
+    flex: 1,
+  },
+  sideLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 2,
+  },
+  sideLabel: {
+    ...textStyles.body,
+    color: colors.textPrimary,
+    fontWeight: typography.fontWeight.semibold,
+    marginRight: spacing.xs,
+  },
+  yourSideBadge: {
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 2,
+    borderRadius: spacing.radius.xs,
+    backgroundColor: colors.primary + '30',
+    marginRight: spacing.xs / 2,
+  },
+  yourSideBadgeText: {
+    ...textStyles.caption,
+    color: colors.primary,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: 9,
+    textTransform: 'uppercase',
+  },
+  winnerBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 2,
+    borderRadius: spacing.radius.xs,
+    backgroundColor: colors.success + '30',
+    marginRight: spacing.xs / 2,
+  },
+  winnerBadgeText: {
+    ...textStyles.caption,
+    color: colors.success,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: 9,
+    textTransform: 'uppercase',
+    marginLeft: 2,
+  },
+  sideCount: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  sideLetter: {
+    ...textStyles.h4,
+    color: colors.textMuted,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: typography.fontSize.sm,
+    width: 20,
+    textAlign: 'right',
+  },
+  vsDivider: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: spacing.xs,
+  },
+  vsDividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: colors.border,
+  },
+  vsText: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    fontWeight: typography.fontWeight.bold,
+    fontSize: 10,
+    paddingHorizontal: spacing.sm,
+  },
+  resolutionReason: {
+    ...textStyles.body,
+    color: colors.textSecondary,
+    fontSize: typography.fontSize.sm,
+    marginTop: spacing.xs / 2,
+  },
+
+  // Debug IDs
+  idRow: {
+    marginBottom: spacing.sm,
+  },
+  idLabel: {
+    ...textStyles.caption,
+    color: colors.textMuted,
+    fontSize: 10,
+    textTransform: 'uppercase',
+    marginBottom: 2,
+  },
+  idValue: {
+    fontFamily: typography.fontFamily.mono,
+    color: colors.textSecondary,
+    fontSize: typography.fontSize.xs,
+    lineHeight: 16,
+  },
+  idValuePlain: {
+    fontFamily: undefined,
+    fontSize: typography.fontSize.sm,
+  },
+
+  bottomPad: {
+    height: spacing.xl,
+  },
+});

--- a/src/screens/BettingHistoryScreen.tsx
+++ b/src/screens/BettingHistoryScreen.tsx
@@ -44,18 +44,23 @@ export const BettingHistoryScreen: React.FC<BettingHistoryScreenProps> = ({ onCl
 
     // Navigate to squares game detail if it's a squares transaction
     if (transaction.relatedSquaresGameId) {
-      // Navigate first, then close modal with delay to ensure navigation completes
       navigation.navigate('Bets', {
         screen: 'SquaresGameDetail',
         params: { gameId: transaction.relatedSquaresGameId }
       });
-      // Close modal after a brief delay to let navigation start
       setTimeout(() => onClose(), 100);
       return;
     }
 
-    // Note: Regular bets (relatedBetId) don't have a detail screen yet,
-    // so we don't navigate for those transactions
+    // Navigate to bet detail page for bet transactions
+    if (transaction.relatedBetId) {
+      navigation.navigate('Bets', {
+        screen: 'BetDetails',
+        params: { betId: transaction.relatedBetId }
+      });
+      setTimeout(() => onClose(), 100);
+      return;
+    }
   };
 
   const fetchTransactions = async () => {
@@ -204,8 +209,8 @@ interface TransactionCardProps {
 }
 
 const TransactionCard: React.FC<TransactionCardProps> = ({ transaction, onPress }) => {
-  // Check if transaction is clickable (only squares games have detail pages)
-  const isClickable = !!transaction.relatedSquaresGameId;
+  // Transactions with a related bet or squares game can navigate to a detail page
+  const isClickable = !!transaction.relatedSquaresGameId || !!transaction.relatedBetId;
   const getTransactionIcon = (): keyof typeof Ionicons.glyphMap => {
     switch (transaction.type) {
       case 'DEPOSIT': return 'arrow-down-circle';


### PR DESCRIPTION
Creates BetDetailsScreen showing full bet info, sides breakdown, user
participation, and a debug panel with Bet ID, Participant ID, Creator ID,
and winning side for easy troubleshooting of won/lost bet discrepancies.

Updates BettingHistoryScreen so any transaction with a relatedBetId is
now tappable and navigates to the new BetDetails screen (same pattern
as existing squares game navigation). Registers BetDetails in the Bets
stack navigator.

https://claude.ai/code/session_01Sxwgv6DFtzJxvi8bNDkJsd